### PR TITLE
Fix (reverse '())

### DIFF
--- a/src/library/r6rs_lib.js
+++ b/src/library/r6rs_lib.js
@@ -875,6 +875,9 @@ if( typeof(BiwaScheme)!='object' ) BiwaScheme={}; with(BiwaScheme) {
     return ret;
   });
   define_libfunc("reverse", 1, 1, function(ar){
+    // (reverse '()) => '()
+    if(ar[0] == nil)
+      return nil;
     assert_pair(ar[0]);
 
     var l = nil;

--- a/test/unit.js
+++ b/test/unit.js
@@ -798,6 +798,7 @@ describe('11.9 Pairs and lists', {
   'reverse' : function(){
     ew("(reverse '(a b c))").should_be("(c b a)");
     ew("(reverse '(a (b c) d (e (f))))").should_be("((e (f)) d (b c) a)");
+    ew("(reverse '())").should_be("()");
   },
   'list-tail' : function(){
     ew("(list-tail '(a b c d) 2)").should_be("(c d)");


### PR DESCRIPTION
Previously the expression `(reverse '())` would crash with an "expected pair" error. While R6RS makes no mention of reversing the empty list, I belive it should result in the empty list as it is both more intuitive and compatible with other Scheme implementations.
