### PR TITLE
Support hex character literals (eg. #\x41 => #\A)

### DIFF
--- a/src/system/parser.js
+++ b/src/system/parser.js
@@ -167,6 +167,20 @@
           return BiwaScheme.Char.get('\t');
         } else if( /^#\\.$/.test(t) ) {
           return BiwaScheme.Char.get( t.charAt(2) );
+        } else if( /^#\\x[a-zA-Z0-9]+$/.test(t) ) {
+          var scalar = parseInt(t.slice(3), 16);
+          // R6RS 11.11 (surrogate codepoints)
+          if (scalar >= 0xD800 && scalar <= 0xDFFF) {
+            throw new BiwaScheme.Error("Character in Unicode excluded range.");
+          }
+          // ECMA-262 4.3.16 -- Basically, strings are sequences of 16-bit
+          // unsigned integers, so anything greater than 0xFFFF won't fit.
+          // NOTE: This violates R6RS which requires the full Unicode range!
+          else if (scalar > 0xFFFF) {
+            throw new BiwaScheme.Error("Character literal out of range.");
+          } else {
+            return BiwaScheme.Char.get(String.fromCharCode(scalar));
+          }
         } else if( /^\"(\\(.|$)|[^\"\\])*\"?$/.test(t) ) {
           return t.replace(/(\r?\n|\\n)/g, "\n").replace( /^\"|\\(.|$)|\"$/g, function($0,$1) {
             return $1 ? $1 : '';

--- a/test/unit.js
+++ b/test/unit.js
@@ -865,13 +865,13 @@ describe('11.11  Characters', {
 //    ev('(char? #\\esc)').should_be(true);
 //    ev('(char? #\\space)').should_be(true);
 //    ev('(char? #\\delete)').should_be(true);
-//    ev('(char? #\\xFF)').should_be(true);
-//    ev('(char? #\\x03BB)').should_be(true);
+    ev('(char? #\\xFF)').should_be(true);
+    ev('(char? #\\x03BB)').should_be(true);
 //    ev('(char? #\\00006587)').should_be(true);
 //    ev('(char? #\\λ)').should_be(true);
-//    ev('(char? #\\xA)').should_be(true);
-//    ev('(char? #\\xFF)').should_be(true);
-//    ev('(char? #\\xff)').should_be(true);
+    ev('(char? #\\xA)').should_be(true);
+    ev('(char? #\\xFF)').should_be(true);
+    ev('(char? #\\xff)').should_be(true);
 //    ev('(char? #\\000000001)').should_be(true);
 //    ev('(char? #\\space)').should_be(true);
   },


### PR DESCRIPTION
According to R6RS section 4.2.6 characters literals can be entered as `#\x<hex scalar value>`. This patch implements parsing of such literals. Surrogate code points (0xB800 through 0xBFFF) are rejected in accordance with the standard.

Unfortunately, since JS strings are sequences of 16-bit unsigned ints, the full Unicode range cannot be represented. Therefore, an error is generated when a character literal is requested whose value exceeds 0xFFFF. This is a violation of R6RS, which requires that the full Unicode range be represented.
