### PR TITLE
Modularity update

### DIFF
--- a/bin/biwas
+++ b/bin/biwas
@@ -4,7 +4,7 @@
 var util = require('util'),
     fs = require('fs'),
     path = require('path'),
-    BiwaScheme = require('biwascheme'),
+    BiwaScheme = require('../release/node_biwascheme'),
     optparse = require('optparse');
 
 function Options(argv){
@@ -43,8 +43,10 @@ function Options(argv){
 }
 
 function repl(){
-  var rl = require('readline').createInterface(process.stdin,
-                                               process.stdout);
+  var rl = require('readline').createInterface(
+    process.stdin,
+    process.stdout
+  );
   var erred = new Object();
 
   rl.on('line', function(line) {
@@ -54,15 +56,13 @@ function repl(){
       var result = erred;
     }
 
-    if (result !== erred) {
+    if (result !== erred && !(result instanceof BiwaScheme.Pause)) {
       util.puts(BiwaScheme.to_write(result));
     }
 
-    rl.prompt();
-  });
-
-  rl.on('close', function() {
-    process.exit(0);
+    if (!(result instanceof BiwaScheme.Pause)) {
+      rl.prompt();
+    }
   });
 
   var prompt = "> ";
@@ -70,6 +70,16 @@ function repl(){
 
   util.puts('BiwaScheme version ' + BiwaScheme.Version);
   util.puts('try (+ 1 2), etc. (Ctrl-D to exit)');
+
+  BiwaScheme.Port.current_input = new BiwaScheme.Port.CustomInput(
+    function (callback) {
+      rl.question('', function (line) {
+        callback(line);
+        rl.prompt()
+      })
+    }
+  );
+
   rl.prompt();
 }
 

--- a/demo/repl.html
+++ b/demo/repl.html
@@ -86,7 +86,7 @@
 
 <script type="text/javascript" src="../src/development_loader.js">// <![CDATA[
 var on_error = function(e){
-  puts(e.message);
+  BiwaScheme.Port.current_error.put_string(e.message);
   throw(e);
 };
 var biwascheme = new BiwaScheme.Interpreter(on_error);
@@ -101,7 +101,7 @@ function bs_eval(){
   biwascheme.evaluate(str, function(result){
     var after = new Date();
     $("#time").html("Time: " + (after-before)/1000 + "sec");
-    puts(BiwaScheme.to_write(result));
+    BiwaScheme.Port.current_output.put_string(BiwaScheme.to_write(result));
   });
 
   return false;

--- a/src/development_loader.js
+++ b/src/development_loader.js
@@ -31,7 +31,6 @@ var BiwaScheme = BiwaScheme || {};
   document.write(script_tag(dir+"src/deps/jquery.js"));
   document.write(script_tag(dir+"src/deps/underscore.js"));
   document.write(script_tag(dir+"src/deps/underscore.string.js"));
-  document.write(script_tag(dir+"src/platforms/browser/console.js"));
   document.write(script_tag(dir+"src/header.js"));
   document.write(script_tag(dir+"src/system/class.js"));
   document.write(script_tag(dir+"src/system/_writer.js"));
@@ -61,6 +60,7 @@ var BiwaScheme = BiwaScheme || {};
   document.write(script_tag(dir+"src/library/node_functions.js"));
   document.write(script_tag(dir+"src/library/srfi.js"));
   document.write(script_tag(dir+"src/platforms/browser/dumper.js"));
+  document.write(script_tag(dir+"src/platforms/browser/console.js"));
   document.write("<script type='text/javascript'>" +
     script.innerHTML +
     "<\/script>");

--- a/src/header.js
+++ b/src/header.js
@@ -2,15 +2,6 @@
 // Heap based scheme from 3imp.pdf
 //
 
-// default definition of puts: should be overriden for console interpreters
-
-function puts(str, no_newline){
-    Console.puts(str, no_newline)
-}
-function p(/*args*/){
-    Console.p.apply(this, arguments)
-}
-
 //
 // variables
 //

--- a/src/library/extra_lib.js
+++ b/src/library/extra_lib.js
@@ -11,7 +11,7 @@ if( typeof(BiwaScheme)!='object' ) BiwaScheme={}; with(BiwaScheme) {
     return BiwaScheme.inspect_objs(ar);
   });
   define_libfunc("inspect!", 1, null, function(ar){
-    puts(BiwaScheme.inspect_objs(ar));
+    Console.puts(BiwaScheme.inspect_objs(ar));
     return BiwaScheme.undef;
   });
 
@@ -300,9 +300,9 @@ if( typeof(BiwaScheme)!='object' ) BiwaScheme={}; with(BiwaScheme) {
 
   define_libfunc("print", 1, null, function(ar){
     _.map(ar, function(item){
-      puts(to_display(item), true);
+      Console.puts(to_display(item), true);
     })
-    puts(""); //newline
+    Console.puts(""); //newline
     return BiwaScheme.undef;
   })
   define_libfunc("write-to-string", 1, 1, function(ar){

--- a/src/library/srfi.js
+++ b/src/library/srfi.js
@@ -333,7 +333,7 @@ with(BiwaScheme) {
   // srfi-38 (write/ss)
   //
   var user_write_ss = function(ar){
-    puts(write_ss(ar[0]), true);
+    Console.puts(write_ss(ar[0]), true);
     return BiwaScheme.undef;
   }
   define_libfunc("write/ss", 1, 2, user_write_ss);

--- a/src/library/webscheme_lib.js
+++ b/src/library/webscheme_lib.js
@@ -405,7 +405,7 @@ if( typeof(BiwaScheme)!='object' ) BiwaScheme={}; with(BiwaScheme) {
     throw new Error("obsolete");
   });
   define_libfunc("dom-remove-children!", 1, 1, function(ar){
-    puts("warning: dom-remove-children! is obsolete. use element-empty! instead");
+    Console.puts("warning: dom-remove-children! is obsolete. use element-empty! instead");
     $(ar[0]).empty();
     return BiwaScheme.undef;
   });

--- a/src/platforms/browser/console.js
+++ b/src/platforms/browser/console.js
@@ -1,17 +1,41 @@
 Console = {}
 
-Console.puts = function(str, no_newline) {
-  var console;
-  var text;
-  console = $("#bs-console");
-  if (console[0]) {
-	text = _.escape(str + (no_newline ? "" : "\n"));
-	var span = $("<span>");
-	span.html(text.replace(/\n/g,"<br>").replace(/ /g,"&nbsp;"));
-	console.append(span);
+BiwaScheme.Port.current_error =
+BiwaScheme.Port.current_output = new BiwaScheme.Port.CustomOutput(
+  function (str) {
+    var console;
+    var text;
+    console = $("#bs-console");
+    if (console[0]) {
+    	text = _.escape(str);
+    	var span = $("<span>");
+    	span.html(text.replace(/\n/g,"<br>").replace(/ /g,"&nbsp;"));
+    	console.append(span);
+    }
   }
+);
+
+BiwaScheme.Port.current_input = new BiwaScheme.Port.CustomInput(
+  function (callback) {
+    var form = $("<form/>");
+    form.html("<input id='webscheme-read-line' type='text'><input type='submit' value='ok'>");
+    $("#bs-console").append(form);
+    form.submit(function(){
+      var input = $("#webscheme-read-line").val();
+      form.remove();
+      callback(input);
+      return false;
+    });
+  }
+);
+
+
+Console.puts = function(str, no_newline) {
+  BiwaScheme.Port.current_output.put_string(str + (no_newline ? "" : "\n"))
 };
 
 Console.p = function (/*ARGS*/){
-  Console.puts("p> "+_.map(_.toArray(arguments), BiwaScheme.inspect).join(" "));
+  BiwaScheme.Port.current_output.put_string(
+    "p> "+_.map(_.toArray(arguments), BiwaScheme.inspect).join(" ")
+  );
 };

--- a/src/platforms/browser/release_initializer.js
+++ b/src/platforms/browser/release_initializer.js
@@ -11,7 +11,7 @@
 
   // Error handler (show message to console div)
   var onError = function(e, state){
-    puts(e.message);
+    BiwaScheme.Port.current_error.puts(e.message);
     if (dumper) {
       dumper.dump(state);
       dumper.dump_move(1);

--- a/src/platforms/node/module_postamble.js
+++ b/src/platforms/node/module_postamble.js
@@ -34,6 +34,29 @@ BiwaScheme.define_libfunc("js-load", 1, 1, function(ar) {
   return require(__dirname + "/../../../" + relpath);
 });
 
+BiwaScheme.Port.current_error =
+BiwaScheme.Port.current_output = new BiwaScheme.Port.CustomOutput(
+  function (str) {
+    require('util').print(str);
+  }
+);
+
+var readline = require('readline');
+BiwaScheme.Port.current_input = new BiwaScheme.Port.CustomInput(
+  function (callback) {
+    var rl = readline.createInterface(
+      process.stdin,
+      process.stdout
+    );
+    rl.on('line', function (line) {
+      rl.close();
+      callback(line);
+    });
+    rl.setPrompt('', 0);
+    rl.prompt()
+  }
+);
+
 for(x in BiwaScheme){
   exports[x] = BiwaScheme[x];
 }

--- a/src/platforms/node/module_preamble.js
+++ b/src/platforms/node/module_preamble.js
@@ -3,18 +3,17 @@ _.str = require('underscore.string');
 
 var Console = {};
 Console.puts = function(str, no_newline) {
-  require('util').print(str);
-  if (!no_newline) {
-    require('util').print("\n");
-  }
+  BiwaScheme.Port.current_output.put_string(str + (no_newline ? "" : "\n"))
 };
 
 Console.p = function() {
-  require('util').print.apply(this, arguments);
+  [].slice.call(arguments).forEach(BiwaScheme.Port.current_output.put_string);
 };
 
 if(typeof(ev) != 'function') {
-  eval("function ev(str){ puts(str); return (new BiwaScheme.Interpreter()).evaluate(str); }");
+  eval(
+    "function ev(str){ Console.puts(str); return (new BiwaScheme.Interpreter()).evaluate(str); }"
+  );
 }
 
 if(typeof(BiwaScheme) == "undefined") BiwaScheme = {};

--- a/src/system/compiler.js
+++ b/src/system/compiler.js
@@ -23,7 +23,7 @@ BiwaScheme.Compiler = BiwaScheme.Class.create({
     for(var i=0; i<arr.length; i++){
       opc = this.compile_refer(arr[i], e, ["argument", opc]);
     }
-    //puts("collect_free "+free.inspect()+" / "+e.inspect()+" => "+opc.inspect());
+    //Console.puts("collect_free "+free.inspect()+" / "+e.inspect()+" => "+opc.inspect());
     return opc;
   },
 
@@ -40,11 +40,11 @@ BiwaScheme.Compiler = BiwaScheme.Class.create({
   compile_lookup: function(x, e, return_local, return_free, return_global){
     var locals = e[0], free = e[1];
     if((n = locals.index(x)) != null){
-      //puts("compile_refer:"+x.inspect()+" in "+e.inspect()+" results refer-local "+n);
+      //Console.puts("compile_refer:"+x.inspect()+" in "+e.inspect()+" results refer-local "+n);
       return return_local(n);
     }
     else if((n = free.index(x)) != null){
-      //puts("compile_refer:"+x.inspect()+" in "+e.inspect()+" results refer-free "+n);
+      //Console.puts("compile_refer:"+x.inspect()+" in "+e.inspect()+" results refer-free "+n);
       return return_free(n);
     }
     else{
@@ -81,7 +81,7 @@ BiwaScheme.Compiler = BiwaScheme.Class.create({
   // v: set(vars)
   // ret: set
   find_sets: function(x, v){
-    //puts("find_sets: " + to_write(x) + " " + to_write(v))
+    //Console.puts("find_sets: " + to_write(x) + " " + to_write(v))
     var ret=null;
     if(x instanceof BiwaScheme.Symbol){
       ret = new BiwaScheme.Set();
@@ -207,7 +207,7 @@ BiwaScheme.Compiler = BiwaScheme.Class.create({
     else{
       ret = new BiwaScheme.Set();
     }
-    //p("find_free "+x.inspect()+" / "+b.inspect()+" => "+ret.inspect());
+    //Console.p("find_free "+x.inspect()+" / "+b.inspect()+" => "+ret.inspect());
 
     if(ret == null)
       throw new BiwaScheme.Bug("find_free() exited in unusual way");
@@ -280,7 +280,7 @@ BiwaScheme.Compiler = BiwaScheme.Class.create({
   // next: opc
   // ret: opc
   compile: function(x, e, s, f, next){
-    //p(x);
+    //Console.p(x);
     var ret = null;
 
     while(1){
@@ -381,8 +381,8 @@ BiwaScheme.Compiler = BiwaScheme.Class.create({
         return ["constant", x, next];
       }
     }
-    //p("result of " + x.inspect() + ":");
-    //p(ret);
+    //Console.p("result of " + x.inspect() + ":");
+    //Console.p(ret);
     //dump({"ret":ret, "x":x, "e":e, "s":s, "next":next, "stack":[]});
 //      if(ret == null)
 //        throw new BiwaScheme.Bug("compile() exited in unusual way");

--- a/src/system/interpreter.js
+++ b/src/system/interpreter.js
@@ -152,7 +152,7 @@ BiwaScheme.Interpreter = BiwaScheme.Class.create({
 
   _execute: function(a, x, f, c, s){
     var ret = null;
-    //puts("executing "+x[0]);
+    //Console.puts("executing "+x[0]);
     
     while(true){ //x[0] != "halt"){
 
@@ -386,7 +386,7 @@ BiwaScheme.Interpreter = BiwaScheme.Class.create({
     if(after_evaluate) 
       this.after_evaluate = after_evaluate;
 
-    if(BiwaScheme.Debug) puts("executing: " + str);
+    if(BiwaScheme.Debug) Console.puts("executing: " + str);
      
     this.is_top = true;
     this.file_stack = [];
@@ -411,7 +411,7 @@ BiwaScheme.Interpreter = BiwaScheme.Class.create({
 
         // compile
         var opc = this.compiler.run(expr);
-        //if(BiwaScheme.Debug) p(opc);
+        //if(BiwaScheme.Debug) Console.p(opc);
 
         // execute
         ret = this.execute(expr, opc, 0, [], 0);

--- a/website/js/biwascheme_terminal.js
+++ b/website/js/biwascheme_terminal.js
@@ -21,10 +21,13 @@ jQuery(document).ready(function($, undefined) {
     var bscheme = new BiwaScheme.Interpreter(function(e, state) {
        term.error(e.message);
     });
-   
-    puts = function(string) {
+
+    Console.puts = function(string) {
         term.echo(string);
     };
+    BiwaScheme.Port.current_output = new BiwaScheme.Port.CustomOutput(
+        Console.puts
+    );
     var code_to_evaluate = '';
     var term = $('#term').terminal(function(command, term) {
         code_to_evaluate += ' ' + command;


### PR DESCRIPTION
We've been patching BiwaScheme with a similar patch to work with repl.it for sometime now but never tried to bring it upstream. The idea is to have less reliance on global functions and make I/O ports configurable.

* Got rid of global `p` and `put`.
* Use Console.p and Console.put in place of globals
* current_input and current_output defaults to Null ports so that users would define these interfaces.
* removed default input/ouput ports in favor of null ports.
* BrowserInput is now defined in the browser/console.js
* Added an input/output implementation for the node platform.
* Added CustomInput and CustomOutput ports for interfacing.
* Fixed Node repl.
* Implemented Node repl read.