### PR TITLE
fixed (atan X 0)

### DIFF
--- a/src/library/r6rs_lib.js
+++ b/src/library/r6rs_lib.js
@@ -667,7 +667,7 @@ if( typeof(BiwaScheme)!='object' ) BiwaScheme={}; with(BiwaScheme) {
   })
   define_libfunc("atan", 1, 2, function(ar){
     assert_number(ar[0]);
-    if(ar[1]){
+    if(ar.length == 2){
       assert_number(ar[1]);
       return Math.atan2(ar[0], ar[1]);
     }


### PR DESCRIPTION
fixed a bug that caused atan to return the wrong result when its second argument was 0
