### PR TITLE
Update year in biwascheme_terminal.js greeting

### DIFF
--- a/website/js/biwascheme_terminal.js
+++ b/website/js/biwascheme_terminal.js
@@ -52,7 +52,7 @@ jQuery(document).ready(function($, undefined) {
         }
     }, {
         greetings: 'BiwaScheme Interpreter version ' + BiwaScheme.Version +
-                   '\nCopyright (C) 2007-2010 Yutaka HARA and the BiwaScheme team',
+                   '\nCopyright (C) 2007-2014 Yutaka HARA and the BiwaScheme team',
         width: 500,
         height: 250,
         name: 'biwa',


### PR DESCRIPTION
A user of the REPL could think the BiwaScheme version is from 2010, even though it is newer.
