### PR TITLE
avoid JS errors for some invalid lists

### DIFF
--- a/src/library/r6rs_lib.js
+++ b/src/library/r6rs_lib.js
@@ -185,6 +185,9 @@ if( typeof(BiwaScheme)!='object' ) BiwaScheme={}; with(BiwaScheme) {
 
     var vars = nil, vals = nil;
     for(var p=binds; p instanceof Pair; p=p.cdr){
+      if(!(p.car instanceof Pair)){
+        throw new Error("let: need a pair for bindings: got "+to_write(p.car));
+      }
       vars = new Pair(p.car.car, vars);
       vals = new Pair(p.car.cdr.car, vals);
     }

--- a/src/system/compiler.js
+++ b/src/system/compiler.js
@@ -372,9 +372,16 @@ BiwaScheme.Compiler = BiwaScheme.Class.create({
                                        : ["apply"]);
 
           // VM will push the number of arguments to the stack.
-          c = this.compile(args.length(), e, s, f, ["argument", c]);
-          for(var p=args; p instanceof BiwaScheme.Pair; p=p.cdr){
-            c = this.compile(p.car, e, s, f, ["argument", c]);
+          if(args.length){
+            // args is Pair or nil
+            c = this.compile(args.length(), e, s, f, ["argument", c]);
+            for(var p=args; p instanceof BiwaScheme.Pair; p=p.cdr){
+              c = this.compile(p.car, e, s, f, ["argument", c]);
+            }
+          }
+          else{
+            c = this.compile(1, e, s, f, ["argument", c]);
+            c = this.compile(args, e, s, f, ["argument", c]);
           }
 
           // Do not push stack frame for tail calls

--- a/src/system/interpreter.js
+++ b/src/system/interpreter.js
@@ -553,9 +553,15 @@ BiwaScheme.Interpreter.expand = function(x, flag/*optional*/){
       }
       else{
         var expanded_car = expand(x.car, flag);
-        var expanded_cdr = BiwaScheme.array_to_list(
-                             _.map(x.cdr.to_array(),
-                                   function(item){ return expand(item, flag); }));
+        var expanded_cdr;
+        if(x.cdr instanceof BiwaScheme.Pair){
+          expanded_cdr = BiwaScheme.array_to_list(
+                           _.map(x.cdr.to_array(),
+                                 function(item){ return expand(item, flag); }));
+        }
+        else{
+          expanded_cdr = expand(x.cdr, flag);
+        }
         ret = new BiwaScheme.Pair(expanded_car, expanded_cdr);
       }
     }


### PR DESCRIPTION
Avoid showing JavaScript error and stopping the interpreter when entering following expressions, which are invalid:

```
(1 . 2)
(let (()) 1)
(let* (()) 1)
```
