### PR TITLE
avoid using deprecated method of express

### DIFF
--- a/local_website.js
+++ b/local_website.js
@@ -5,13 +5,11 @@
 //
 
 var express = require('express'),
-    app = require('express').createServer(),
+    app = require('express')(),
     fs = require('fs');
 
-app.configure(function(){
-  app.use(express.static(__dirname));
-  //app.use(express.errorHandler({ dumpExceptions: true, showStack: true }));
-});
+app.use(express.static(__dirname));
+//app.use(express.errorHandler({ dumpExceptions: true, showStack: true }));
 
 //app.get('/', function(req, res){
 //  res.send('hello world');


### PR DESCRIPTION
The original code using  `require('express').createServer()` and `app.configure` couldn't be run on express 4.10.4
I think it is because these methods are deprecated.
So, I avoided to use these methods and tested with express 4.10.4 and 3.18.4

References:
- [node.js - I'm not able to solve an error in nodejs using express framework - Stack Overflow](http://stackoverflow.com/questions/23071197/im-not-able-to-solve-an-error-in-nodejs-using-express-framework)
- [javascript - Express has no method configure error - Stack Overflow](http://stackoverflow.com/questions/22202232/express-has-no-method-configure-error)
