### PR TITLE
replace embedded scheme code eval with included files through `<script>` eval 

### DIFF
--- a/demo/biwascheme.js
+++ b/demo/biwascheme.js
@@ -1,0 +1,1 @@
+../release/biwascheme.js

--- a/demo/simple.html
+++ b/demo/simple.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ja">
+<head>
+<meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
+<title>External Script - BiwaScheme</title>
+</head>
+<body>
+
+  <h1>
+    <a href='../index.html'>BiwaScheme</a> REPL
+    <small id="biwa_ver"></small>
+  </h1>
+
+  <script type="text/scheme" src="simple.scm"></script>
+  <script type="text/scheme" src="simple2.scm"></script>
+  <script type="text/javascript" src="biwascheme.js"></script>
+</body>
+</html>
+<!-- vim:set ft=javascript: -->

--- a/demo/simple.scm
+++ b/demo/simple.scm
@@ -1,0 +1,1 @@
+(console-log "Hello from BiwaScheme")

--- a/demo/simple2.scm
+++ b/demo/simple2.scm
@@ -1,0 +1,1 @@
+(console-log "Hello again!")

--- a/src/platforms/browser/release_initializer.js
+++ b/src/platforms/browser/release_initializer.js
@@ -23,15 +23,21 @@
   };
 
   // Start user's program
-  var script = $("script[src$='biwascheme.js']").html() ||
-               $("script[src$='biwascheme-min.js']").html();
-  if (script) {
-    var intp = new BiwaScheme.Interpreter(onError);
-    try{
-      intp.evaluate(script, function(){});
-    }
-    catch(e){
-      onError(e);
-    }
-  }
+  var intp = new BiwaScheme.Interpreter(onError);
+
+    var scripts = $("script[type=\"text/scheme\"]");
+    console.log(scripts);
+    scripts.each(function(index, script) {
+        var scheme = $.ajax({
+            type: "GET",
+            url: $(script).attr('src'),
+            async: false
+        }).responseText;
+        try{
+            intp.evaluate(scheme, function(){});
+        }
+        catch(e){
+            onError(e);
+        }
+    });
 })();


### PR DESCRIPTION
Instead of using this code

```html
<script type="text/javascript" src="biwascheme.js">
(console-log "Héllo")
</script>
```

This PR implements the use of linked scripts using scripts tags that appear **before** biwascheme is linked:

```html
  <script type="text/scheme" src="simple.scm"></script>
  <script type="text/scheme" src="simple2.scm"></script>
  <script type="text/javascript" src="biwascheme.js"></script>
```

There is an example in the repository.