### PR TITLE
Fix string->number

### DIFF
--- a/src/library/infra.js
+++ b/src/library/infra.js
@@ -179,6 +179,36 @@ BiwaScheme.deprecate = function(title, ver, alt){
 // utils
 //
 
+// Parses a fractional notation in the format: <num>/<denom> (e.g. 3/7, -9/4),
+// where <num> is a valid integer notation, and <denom> is a valid notation
+// for a positive integer.
+//
+// Returns a float if the notation is valid, otherwise false.
+//
+// @param {string} rep - the string representation of the fraction
+BiwaScheme.parse_fraction = function(rep) {
+  BiwaScheme.assert_string(rep);
+
+  var frac_parts = rep.split('/');
+
+  if (frac_parts.length !== 2)
+    return false;
+
+  var num_rep = frac_parts[0];
+  var denom_rep = frac_parts[1];
+
+  var num = BiwaScheme.parse_integer(num_rep, 10);
+  var denom = BiwaScheme.parse_integer(denom_rep, 10);
+
+  if (num === false || denom === false)
+    return false;
+
+  if (denom <= 0)
+    return false;
+
+  return num / denom;
+};
+
 // Given a string notation of an integer, and the radix, validates the
 // notation: returns true if the notation is valid, otherwise false.
 //

--- a/src/library/infra.js
+++ b/src/library/infra.js
@@ -186,6 +186,7 @@ BiwaScheme.deprecate = function(title, ver, alt){
 // Returns a float if the notation is valid, otherwise false.
 //
 // @param {string} rep - the string representation of the fraction
+// @return {float|false}
 BiwaScheme.parse_fraction = function(rep) {
   BiwaScheme.assert_string(rep);
 
@@ -214,6 +215,7 @@ BiwaScheme.parse_fraction = function(rep) {
 //
 // @param {string} rep - the string representation of the integer
 // @param {integer} rdx - the radix, where 2 <= rdx <= 36
+// @return {boolean}
 BiwaScheme.is_valid_integer_notation = function(rep, rdx) {
   BiwaScheme.assert_string(rep);
   BiwaScheme.assert_integer(rdx);
@@ -235,6 +237,7 @@ BiwaScheme.is_valid_integer_notation = function(rep, rdx) {
 //
 // @param {string} rep - the string representation of the integer
 // @param {integer} rdx - the radix, where 2 <= rdx <= 36
+// @return {integer|false}
 BiwaScheme.parse_integer = function(rep, rdx) {
   BiwaScheme.assert_string(rep);
   BiwaScheme.assert_integer(rdx);
@@ -258,6 +261,7 @@ BiwaScheme.parse_integer = function(rep, rdx) {
 // returned.
 //
 // @param {string} rep - the string representation of the floating-point value
+// @return {float|false}
 BiwaScheme.parse_float = function(rep) {
   BiwaScheme.assert_string(rep);
 

--- a/src/library/infra.js
+++ b/src/library/infra.js
@@ -174,3 +174,26 @@ BiwaScheme.deprecate = function(title, ver, alt){
             "Please use "+alt+" instead";
   console.warn(msg); 
 };
+
+//
+// utils
+//
+
+// Parse a floating-point number. If the floating-point number does not have a
+// valid representation, or produces -Infinity, +Infinity or NaN, - false is
+// returned.
+//
+// @param {string} rep - the string representation of the floating-point value
+BiwaScheme.parse_float = function(rep) {
+  BiwaScheme.assert_string(rep);
+
+  var res = new Number(rep).valueOf();
+
+  if (Number.isNaN(res))
+    return false;
+
+  if (!Number.isFinite(res))
+    return false;
+
+  return res;
+};

--- a/src/library/infra.js
+++ b/src/library/infra.js
@@ -256,6 +256,32 @@ BiwaScheme.parse_integer = function(rep, rdx) {
   return res;
 };
 
+// Given a string notation of a floating-point number in the standard or
+// scientific notation, returns true if the notation valid, otherwise false.
+//
+// For example:
+// "1"      -> true
+// "1."     -> true
+// "1.23"   -> true
+// "1e4"    -> true
+// "1E4"    -> true
+// "1E4.34" -> false
+// "e34"    -> false
+//
+// @param {string} rep - the string representation of the float.
+// @return {boolean}
+BiwaScheme.is_valid_float_notation = function(rep) {
+  BiwaScheme.assert_string(rep);
+
+  var sci_regex = /^[+-]?[0-9]+[.]?[0-9]*e[+-]?[0-9]+$/ig;
+  var fp_regex  = /(^[+-]?[0-9]*[.][0-9]+$)|(^[+-]?[0-9]+[.][0-9]*$)/g;
+
+  if (sci_regex.test(rep) || fp_regex.test(rep))
+    return true;
+
+  return BiwaScheme.is_valid_integer_notation(rep, 10);
+};
+
 // Parse a floating-point number. If the floating-point number does not have a
 // valid representation, or produces -Infinity, +Infinity or NaN, - false is
 // returned.
@@ -264,6 +290,9 @@ BiwaScheme.parse_integer = function(rep, rdx) {
 // @return {float|false}
 BiwaScheme.parse_float = function(rep) {
   BiwaScheme.assert_string(rep);
+
+  if (!BiwaScheme.is_valid_float_notation(rep))
+    return false;
 
   var res = new Number(rep).valueOf();
 

--- a/src/library/infra.js
+++ b/src/library/infra.js
@@ -273,8 +273,8 @@ BiwaScheme.parse_integer = function(rep, rdx) {
 BiwaScheme.is_valid_float_notation = function(rep) {
   BiwaScheme.assert_string(rep);
 
-  var sci_regex = /^[+-]?[0-9]+[.]?[0-9]*e[+-]?[0-9]+$/ig;
-  var fp_regex  = /(^[+-]?[0-9]*[.][0-9]+$)|(^[+-]?[0-9]+[.][0-9]*$)/g;
+  var sci_regex = /^[+-]?[0-9]+[.]?[0-9]*e[+-]?[0-9]+$/i;
+  var fp_regex  = /(^[+-]?[0-9]*[.][0-9]+$)|(^[+-]?[0-9]+[.][0-9]*$)/;
 
   if (sci_regex.test(rep) || fp_regex.test(rep))
     return true;

--- a/src/library/infra.js
+++ b/src/library/infra.js
@@ -179,6 +179,50 @@ BiwaScheme.deprecate = function(title, ver, alt){
 // utils
 //
 
+// Given a string notation of an integer, and the radix, validates the
+// notation: returns true if the notation is valid, otherwise false.
+//
+// @param {string} rep - the string representation of the integer
+// @param {integer} rdx - the radix, where 2 <= rdx <= 36
+BiwaScheme.is_valid_integer_notation = function(rep, rdx) {
+  BiwaScheme.assert_string(rep);
+  BiwaScheme.assert_integer(rdx);
+
+  if (rdx < 2 || rdx > 36)
+    return false;
+
+  var rdx_symbols = '0123456789abcdefghijklmnopqrstuvwxyz';
+
+  var valid_symbols = rdx_symbols.slice(0, rdx);
+  var sym_regex = new RegExp('^[+-]?' + '[' + valid_symbols + ']+$', 'ig');
+
+  return sym_regex.test(rep);
+};
+
+// Parse an integer. If the integer does not have a valid representation, or
+// produces NaN, - false is returned. If the radix is not within [2..36]
+// range, false is returned as well.
+//
+// @param {string} rep - the string representation of the integer
+// @param {integer} rdx - the radix, where 2 <= rdx <= 36
+BiwaScheme.parse_integer = function(rep, rdx) {
+  BiwaScheme.assert_string(rep);
+  BiwaScheme.assert_integer(rdx);
+
+  if (rdx < 2 || rdx > 36)
+    return false;
+
+  if (!BiwaScheme.is_valid_integer_notation(rep, rdx))
+    return false;
+
+  var res = parseInt(rep, rdx);
+
+  if (Number.isNaN(res))
+    return false;
+
+  return res;
+};
+
 // Parse a floating-point number. If the floating-point number does not have a
 // valid representation, or produces -Infinity, +Infinity or NaN, - false is
 // returned.

--- a/src/library/r6rs_lib.js
+++ b/src/library/r6rs_lib.js
@@ -752,17 +752,40 @@ if( typeof(BiwaScheme)!='object' ) BiwaScheme={}; with(BiwaScheme) {
     return z.toString(radix);
   })
   define_libfunc("string->number", 1, 3, function(ar){
-    var s = ar[0], radix = ar[1] || 10;
-    switch(s){
-      case "+inf.0": return Infinity;
-      case "-inf.0": return -Infinity;
-      case "+nan.0": return NaN;
-      default:       if(s.match(/[eE.]/))
-                       return parseFloat(s);
-                     else
-                       return parseInt(s, radix);
+    var s = ar[0];
 
-    }
+    if (s === '+inf.0')
+      return Infinity;
+
+    if (s === '-inf.0')
+      return -Infinity;
+
+    if (s === '+nan.0')
+      return NaN;
+
+    var radix = ar[1];
+    
+    var int_res = BiwaScheme.parse_integer(
+      s, radix === 0 ? 0 : radix || 10
+    );
+
+    if (int_res !== false)
+      return int_res;
+
+    if (radix !== undefined && radix !== 10)
+      return false;
+
+    var fp_res = BiwaScheme.parse_float(s);
+
+    if (fp_res !== false)
+      return fp_res;
+
+    var frac_res = BiwaScheme.parse_fraction(s);
+
+    if (frac_res !== false)
+      return frac_res;
+
+    return false;
   })
 
   //

--- a/test/unit.js
+++ b/test/unit.js
@@ -2361,6 +2361,53 @@ describe('srfi-62 s-expr comment', {
 // Node.js only
 
 describe('infra', {
+  'parse_fraction, invalid "rep" param': function() {
+    js_should_raise_error(function() {
+      BiwaScheme.parse_fraction([], 10);
+    });
+
+    js_should_raise_error(function() {
+      BiwaScheme.parse_fraction({}, 2);
+    });
+
+    js_should_raise_error(function() {
+      BiwaScheme.parse_fraction('123', 10);
+    });
+  },
+  'parse_fraction, valid, positive': function() {
+    expect(BiwaScheme.parse_fraction('1/1')).should_be(1.0);
+    expect(BiwaScheme.parse_fraction('10/5')).should_be(2.0);
+    expect(BiwaScheme.parse_fraction('3/5')).should_be(3 / 5.0);
+  },
+  'parse_fraction, valid, negative': function() {
+    expect(BiwaScheme.parse_fraction('-1/1')).should_be(-1.0);
+    expect(BiwaScheme.parse_fraction('-10/5')).should_be(-2.0);
+    expect(BiwaScheme.parse_fraction('-3/5')).should_be(-3 / 5.0);
+  },
+  'parse_fraction, valid, zero numerator': function() {
+    expect(BiwaScheme.parse_fraction('0/1')).should_be(0.0);
+    expect(BiwaScheme.parse_fraction('-0/1')).should_be(0.0);
+    expect(BiwaScheme.parse_fraction('+0/1')).should_be(0.0);
+  },
+  'parse_fraction, invalid, zero denominator': function() {
+    expect(BiwaScheme.parse_fraction('0/0')).should_be(false);
+    expect(BiwaScheme.parse_fraction('3/0')).should_be(false);
+    expect(BiwaScheme.parse_fraction('-3/0')).should_be(false);
+  },
+  'parse_fraction, invalid, negative denominator': function() {
+    expect(BiwaScheme.parse_fraction('5/-25')).should_be(false);
+    expect(BiwaScheme.parse_fraction('9/(-26)')).should_be(false);
+    expect(BiwaScheme.parse_fraction('(9/-35)')).should_be(false);
+    expect(BiwaScheme.parse_fraction('5/-74')).should_be(false);
+  },
+  'parse_fraction, invalid': function() {
+    expect(BiwaScheme.parse_fraction('1')).should_be(false);
+    expect(BiwaScheme.parse_fraction('-1')).should_be(false);
+    expect(BiwaScheme.parse_fraction('0')).should_be(false);
+    expect(BiwaScheme.parse_fraction('(9/35)')).should_be(false);
+    expect(BiwaScheme.parse_fraction('fff/fff')).should_be(false);
+    expect(BiwaScheme.parse_fraction('abc')).should_be(false);
+  },
   'is_valid_integer_notation, invalid "rep" param': function() {
     js_should_raise_error(function() {
       BiwaScheme.is_valid_integer_notation([], 10);

--- a/test/unit.js
+++ b/test/unit.js
@@ -885,6 +885,12 @@ describe('11.7 Arithmetic', {
     ev('(string->number "-inf.0")').should_be(-Infinity)
     ew('(string->number "+nan.0")').should_be("+nan.0")
   },
+  'string->number, invalid "radix" param ': function() {
+    ev('(string->number "2" 0)').should_be(false);
+    ev('(string->number "2.34" 0)').should_be(false);
+    should_raise_error('(string->number "2.34" `())');
+    should_raise_error('(string->number "2.34" "2")');
+  },
   'string->number, valid, sci-float, explicit base 10': function() {
     ev('(string->number "2.34" 10)').should_be(2.34);
     ev('(string->number "-3e5" 10)').should_be(-3e5);

--- a/test/unit.js
+++ b/test/unit.js
@@ -2361,6 +2361,156 @@ describe('srfi-62 s-expr comment', {
 // Node.js only
 
 describe('infra', {
+  'is_valid_integer_notation, invalid "rep" param': function() {
+    js_should_raise_error(function() {
+      BiwaScheme.is_valid_integer_notation([], 10);
+    });
+
+    js_should_raise_error(function() {
+      BiwaScheme.is_valid_integer_notation({}, 2);
+    });
+
+    js_should_raise_error(function() {
+      BiwaScheme.is_valid_integer_notation('123', 10);
+    });
+  },
+  'is_valid_integer_notation, invalid "rdx" param': function() {
+    js_should_raise_error(function() {
+      BiwaScheme.is_valid_integer_notation('0', []);
+    });
+
+    js_should_raise_error(function() {
+      BiwaScheme.is_valid_integer_notation('0', {});
+    });
+
+    js_should_raise_error(function() {
+      BiwaScheme.is_valid_integer_notation('0', '2');
+    });
+  },
+  'is_valid_integer_notation, with radix outside of 2..36 range': function() {
+    expect(BiwaScheme.is_valid_integer_notation('2', 0)).should_be(false);
+    expect(BiwaScheme.is_valid_integer_notation('0', -1)).should_be(false);
+    expect(BiwaScheme.is_valid_integer_notation('1', -2)).should_be(false);
+    expect(BiwaScheme.is_valid_integer_notation('1', -2)).should_be(false);
+    expect(BiwaScheme.is_valid_integer_notation('-5', 1)).should_be(false);
+    expect(BiwaScheme.is_valid_integer_notation('5', 37)).should_be(false);
+    expect(BiwaScheme.is_valid_integer_notation('7', 45)).should_be(false);
+  },
+  'is_valid_integer_notation, valid': function() {
+    expect(BiwaScheme.is_valid_integer_notation('+10010', 2)).should_be(true);
+    expect(BiwaScheme.is_valid_integer_notation('-2122', 3)).should_be(true);
+    expect(BiwaScheme.is_valid_integer_notation('3212', 4)).should_be(true);
+    expect(BiwaScheme.is_valid_integer_notation('612543', 7)).should_be(true);
+
+    expect(BiwaScheme.is_valid_integer_notation('7154372', 8)).should_be(true);
+    expect(BiwaScheme.is_valid_integer_notation('53216', 9)).should_be(true);
+    expect(BiwaScheme.is_valid_integer_notation('642366', 10)).should_be(true);
+    expect(BiwaScheme.is_valid_integer_notation('3532a5', 11)).should_be(true);
+
+    expect(BiwaScheme.is_valid_integer_notation('aB3214', 12)).should_be(true);
+    expect(BiwaScheme.is_valid_integer_notation('cba132', 13)).should_be(true);
+    expect(BiwaScheme.is_valid_integer_notation('FFbce', 16)).should_be(true);
+    expect(BiwaScheme.is_valid_integer_notation('jka389', 21)).should_be(true);
+
+    expect(BiwaScheme.is_valid_integer_notation('vwuacb', 33)).should_be(true);
+    expect(BiwaScheme.is_valid_integer_notation('-xACB4', 34)).should_be(true);
+    expect(BiwaScheme.is_valid_integer_notation('+10xy', 35)).should_be(true);
+    expect(BiwaScheme.is_valid_integer_notation('xyz', 36)).should_be(true);
+  },
+  'is_valid_integer_notation, invalid': function() {
+    expect(BiwaScheme.is_valid_integer_notation('+10012', 2)).should_be(false);
+    expect(BiwaScheme.is_valid_integer_notation('-2322', 3)).should_be(false);
+    expect(BiwaScheme.is_valid_integer_notation('3242', 4)).should_be(false);
+    expect(BiwaScheme.is_valid_integer_notation('67543', 7)).should_be(false);
+    
+    expect(BiwaScheme.is_valid_integer_notation('784372', 8)).should_be(false);
+    expect(BiwaScheme.is_valid_integer_notation('95916', 9)).should_be(false);
+    expect(BiwaScheme.is_valid_integer_notation('6e266', 10)).should_be(false);
+    expect(BiwaScheme.is_valid_integer_notation('3a2b5', 11)).should_be(false);
+    
+    expect(BiwaScheme.is_valid_integer_notation('az214', 12)).should_be(false);
+    expect(BiwaScheme.is_valid_integer_notation('cby32', 13)).should_be(false);
+    expect(BiwaScheme.is_valid_integer_notation('fbke', 16)).should_be(false);
+    expect(BiwaScheme.is_valid_integer_notation('++jk9', 21)).should_be(false);
+
+    expect(BiwaScheme.is_valid_integer_notation('vwuzz', 33)).should_be(false);
+    expect(BiwaScheme.is_valid_integer_notation('--ab4', 34)).should_be(false);
+    expect(BiwaScheme.is_valid_integer_notation('+10xz', 35)).should_be(false);
+    expect(BiwaScheme.is_valid_integer_notation('++xyz', 36)).should_be(false);
+  },
+  'parse_integer, invalid "rep" param': function() {
+    js_should_raise_error(function() {
+      BiwaScheme.parse_integer([], 10);
+    });
+
+    js_should_raise_error(function() {
+      BiwaScheme.parse_integer({}, 2);
+    });
+
+    js_should_raise_error(function() {
+      BiwaScheme.parse_integer('123', 10);
+    });
+  },
+  'parse_integer, invalid "rdx" param': function() {
+    js_should_raise_error(function() {
+      BiwaScheme.parse_integer('0', []);
+    });
+
+    js_should_raise_error(function() {
+      BiwaScheme.parse_integer('0', {});
+    });
+
+    js_should_raise_error(function() {
+      BiwaScheme.parse_integer('0', '2');
+    });
+  },
+  'parse_integer, with radix outside of 2..36 range': function() {
+    expect(BiwaScheme.parse_integer('2', 0)).should_be(false);
+    expect(BiwaScheme.parse_integer('0', -1)).should_be(false);
+    expect(BiwaScheme.parse_integer('1', -2)).should_be(false);
+    expect(BiwaScheme.parse_integer('1', -2)).should_be(false);
+    expect(BiwaScheme.parse_integer('-5', 1)).should_be(false);
+    expect(BiwaScheme.parse_integer('5', 37)).should_be(false);
+    expect(BiwaScheme.parse_integer('7', 45)).should_be(false);
+  },
+  'parse_integer, valid, positive, base-10 radix': function() {
+    expect(BiwaScheme.parse_integer('10', 10)).should_be(10);
+    expect(BiwaScheme.parse_integer('123', 10)).should_be(123);
+    expect(BiwaScheme.parse_integer('+5', 10)).should_be(5);
+    expect(BiwaScheme.parse_integer('5', 10)).should_be(5);
+    expect(BiwaScheme.parse_integer('37', 10)).should_be(37);
+  },
+  'parse_integer, valid, zero, base-10 radix': function() {
+    expect(BiwaScheme.parse_integer('0', 10)).should_be(0);
+    expect(BiwaScheme.parse_integer('-0', 10)).should_be(0);
+    expect(BiwaScheme.parse_integer('0', 10)).should_be(0);
+  },
+  'parse_integer, valid, negative, base-10 radix': function() {
+    expect(BiwaScheme.parse_integer('-5', 10)).should_be(-5);
+    expect(BiwaScheme.parse_integer('-345', 10)).should_be(-345);
+    expect(BiwaScheme.parse_integer('-37', 10)).should_be(-37);
+    expect(BiwaScheme.parse_integer('-41', 10)).should_be(-41);
+  },
+  'parse_integer, valid, positive, with radix': function() {
+    expect(BiwaScheme.parse_integer('1010', 2)).should_be(10);
+    expect(BiwaScheme.parse_integer('fff', 16)).should_be(4095);
+    expect(BiwaScheme.parse_integer('243342', 8)).should_be(83682);
+    expect(BiwaScheme.parse_integer('1', 25)).should_be(1);
+    expect(BiwaScheme.parse_integer('43312314', 5)).should_be(369709);
+  },
+  'parse_integer, valid, zero, with radix': function() {
+    expect(BiwaScheme.parse_integer('0', 2)).should_be(0);
+    expect(BiwaScheme.parse_integer('0', 5)).should_be(0);
+    expect(BiwaScheme.parse_integer('0', 3)).should_be(0);
+    expect(BiwaScheme.parse_integer('0', 4)).should_be(0);
+  },
+  'parse_integer, valid, negative, with radix': function() {
+    expect(BiwaScheme.parse_integer('-1010', 2)).should_be(-10);
+    expect(BiwaScheme.parse_integer('-fff', 16)).should_be(-4095);
+    expect(BiwaScheme.parse_integer('-243342', 8)).should_be(-83682);
+    expect(BiwaScheme.parse_integer('-1', 25)).should_be(-1);
+    expect(BiwaScheme.parse_integer('-43312314', 5)).should_be(-369709);
+  },
   'parse_float, invalid param': function() {
     js_should_raise_error(function() {
       BiwaScheme.parse_float('');

--- a/test/unit.js
+++ b/test/unit.js
@@ -870,6 +870,17 @@ describe('11.7 Arithmetic', {
     ev('(string->number "+inf.0")').should_be(Infinity)
     ev('(string->number "-inf.0")').should_be(-Infinity)
     ew('(string->number "+nan.0")').should_be("+nan.0")
+  },
+  'string->number, invalid number notation' : function() {
+    ev('(string->number "abc")').should_be(false);
+    ev('(string->number "ABC")').should_be(false);
+    ev('(string->number "d")').should_be(false);
+    ev('(string->number "D")').should_be(false);
+    ev('(string->number "")').should_be(false);
+    ev('(string->number "1r")').should_be(false);
+    ev('(string->number "1.23xy")').should_be(false);
+    ev('(string->number "1.23r")').should_be(false);
+    ev('(string->number "1.23R")').should_be(false);
   }
 })
 


### PR DESCRIPTION
#115 

The following has been fixed/implemented for `string->number`:
- support for fractional notation , e.g. `"1/5", `"3/7"`, `"5/3"`, `"-5/7"`
- `(string->number "0/0")` now returns `false`
- `"abc"` and other invalid numeric representations now return `false`: `(string->number "123abc")` now returns `false`
- integer representations with leading whitespace are not considered invalid, and produce `false`
- if the `radix` param is present and is not an integer, an error is thrown
- radix values less than 2 or greater than 36 now produce `false`

### Call-chain hierarchy, regarding to the newly implemented functions:

```
string->number
|
|---> BiwaScheme.parse_integer
|     |
|     |---> BiwaScheme.is_valid_integer_notation
|
|---> BiwaScheme.parse_float
|     |
|     |---> BiwaScheme.is_valid_float_notation
|     |---> BiwaScheme.is_valid_integer_notation
|
|---> BiwaScheme.parse_fraction
|     |
|     |---> BiwaScheme.is_valid_integer_notation
```
