### PR TITLE
Allow an empty list of bindings in let*.

### DIFF
--- a/src/library/r6rs_lib.js
+++ b/src/library/r6rs_lib.js
@@ -218,6 +218,9 @@ if( typeof(BiwaScheme)!='object' ) BiwaScheme={}; with(BiwaScheme) {
     //     (let ((b a)) (print a) (+ a b)))
     var binds = x.cdr.car, body = x.cdr.cdr;
 
+    if(binds === nil)
+      return new Pair(Sym("let"), new Pair(nil, body));
+
     if(!(binds instanceof Pair))
       throw new Error("let*: need a pair for bindings: got "+to_write(binds));
 

--- a/test/node_functions.js
+++ b/test/node_functions.js
@@ -20,6 +20,15 @@ var puts = console.log;
 puts("Running tests...");
 
 var tests = {
+  // R6RS core
+  "let ()": function(){
+    assert.ok(ev('(let () #t)'));
+  },
+
+  "let* ()": function(){
+    assert.ok(ev('(let* () #t)'));
+  },
+
   // R6RS stdlib 9
   "file-exists? (#t)": function(){
     assert.ok(ev('(file-exists? "Makefile")'));

--- a/test/node_functions.js
+++ b/test/node_functions.js
@@ -20,15 +20,6 @@ var puts = console.log;
 puts("Running tests...");
 
 var tests = {
-  // R6RS core
-  "let ()": function(){
-    assert.ok(ev('(let () #t)'));
-  },
-
-  "let* ()": function(){
-    assert.ok(ev('(let* () #t)'));
-  },
-
   // R6RS stdlib 9
   "file-exists? (#t)": function(){
     assert.ok(ev('(file-exists? "Makefile")'));

--- a/test/unit.js
+++ b/test/unit.js
@@ -382,10 +382,12 @@ describe('syntaxes', {
     ev("(let ((x 2) (y 3)) (* x y))").should_be(6);
     ev("(let ((x 2) (y 3)) (let ((x 7) (z (+ x y))) (* z x)))").should_be(35);
     ev("((lambda (x) (let ((f 9)) (let ((k 90)) (set! k 43) x))) 31)").should_be(31);
+    ev('(let () 1)').should_be(1);
   },
   'let*' : function(){
     ev("(let* ((x 1) (y x)) y)").should_be(1);
     ev("(let ((x 2) (y 3)) (let* ((x 7) (z (+ x y))) (* z x)))").should_be(70);
+    ev('(let* () 1)').should_be(1);
   },
   'named let' : function(){
     ev("(let loop ((i 0) (x 0)) (if (= i 5) x (loop (+ i 1) (- x 1))))").should_be(-5);


### PR DESCRIPTION
R6RS (and R7RS, and R5RS) allows an empty list of bindings in `let`, and also in `let*`.

Currently, BiwaScheme accepts an empty list of bindings in `let`, but not in `let*`.

This change makes it also accept an empty list of bindings in `let*`.