### PR TITLE
use UTF-8 encoding for (load path)

### DIFF
--- a/src/library/webscheme_lib.js
+++ b/src/library/webscheme_lib.js
@@ -306,7 +306,7 @@ if( typeof(BiwaScheme)!='object' ) BiwaScheme={}; with(BiwaScheme) {
     return new BiwaScheme.Pause(function(pause){
       $.ajax(path, {
         dataType: "text",
-        mimeType: "text/plain; charset=x-user-defined", // For Firefox (#88)
+        mimeType: "text/plain; charset=UTF-8", // For Firefox (#88)
         success: function(data) {
           // create new interpreter not to destroy current stack.
           intp2.evaluate(data,


### PR DESCRIPTION
Fixes an encoding issue. To reproduce:

```
#+title: minimal working example
#+HTML_HEADER: <meta charset="utf-8" />

MWE (also needs mwe.scm):

#+BEGIN_EXPORT HTML
    <p><span id="result"> &nbsp; </span></p>
    <script src="biwascheme.js">
      (load "mwe.scm")
      (set-content! "#result" (umlauts))
    </script>
#+END_EXPORT

#+begin_src scheme :tangle mwe.scm
(define (umlauts)
  "äöüß")
#+end_src
```