### PR TITLE
fix unintended behavior change of element-read-attribute, etc.

### DIFF
--- a/src/library/webscheme_lib.js
+++ b/src/library/webscheme_lib.js
@@ -21,7 +21,7 @@ define_libfunc("read-line", 0, 1, function(ar){
 // element
 //
 define_libfunc("element-empty!", 1, 1, function(ar){
-  if ($(ar[0]).attr("value")) {
+  if ($(ar[0]).prop("value")) {
     return $(ar[0]).val("");
   } else {
     return $(ar[0]).empty();
@@ -102,12 +102,12 @@ define_libfunc("element-identify", 1, 1, function(ar){
 });
 define_libfunc("element-read-attribute", 2, 2, function(ar){
   assert_string(ar[1]);
-  return $(ar[0]).attr(ar[1]);
+  return $(ar[0]).prop(ar[1]);
 });
 
 var element_write_attribute = function(ar) {
   assert_string(ar[1]);
-  return $(ar[0]).attr(ar[1], ar[2]);
+  return $(ar[0]).prop(ar[1], ar[2]);
 };
 define_libfunc("element-write-attribute", 3, 3, function(ar){
   deprecate("element-write-attribute", "1.0",
@@ -298,7 +298,7 @@ define_libfunc("element-new", 1, 1, function(ar){
 });
 
 const element_content = function(selector) {
-  if ($(selector).attr("value")) {
+  if ($(selector).prop("value")) {
     return $(selector).val();
   } else {
     return _.escape($(selector).html());

--- a/test/browser_functions/gh_212.html
+++ b/test/browser_functions/gh_212.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" /> 
+  <!--
+    <script src="../release/biwascheme-0.7.0.js"></script>
+    <script type="module" src="../release/biwascheme-0.7.1.js"></script>
+  -->
+    <script type="module" src="../src/main-browser.js"></script>
+</head>
+<body>
+  <h3>https://github.com/biwascheme/biwascheme/issues/212</h3>
+  <div>
+    <ol>
+      <li>Type "ok" in the input box</li>
+      <li>Press "Test"</li>
+  </div>
+  <div>
+    <div id="div1" class="ok">ok</div>
+    <input id="input1" type="text">
+  </div>
+  <table>
+    <tr><th>Test</th><th>Result</th><th>Expected</th></tr>
+    <tr><td>Test 1 (element-content div1)</td><td> <span id="ans1"></span></td><td>"ok"</td></tr>
+    <tr><td>Test 2 (element-content input1)</td><td> <span id="ans2"></span></td><td>"ok"</td></tr>
+    <tr><td>Test 3 (element-read-attribute div1 "class")</td><td> <span id="ans3"></span></td><td>"ok"</td></tr>
+    <tr><td>Test 4 (element-read-attribute input1 "value")</td><td> <span id="ans4"></span></td><td>"ok"</td></tr>
+    <tr><td>Test 5 (element-write-attribute div1 "class" "OK")</td><td> <span id="ans5"></span></td><td>"OK"</td></tr>
+    <tr><td>Test 6 (element-write-attribute input1 "value" "OK")</td><td> <span id="ans6"></span></td><td>"OK"</td></tr>
+    <tr><td>Test 7 (element-empty! div1)</td><td> <span id="ans7"></span></td><td>""</td></tr>
+    <tr><td>Test 8 (element-empty! input1)</td><td> <span id="ans8"></span></td><td>""</td></tr>
+  </table>
+
+        <div id="bs-console"></div>
+        <button id="button">Test</button>
+        <script type="text/biwascheme">
+(define (test)
+  (define div1 ($ "#div1"))
+  (define input1 ($ "#input1"))
+
+  (set-content! ($ "#ans1") (write-to-string (element-content div1)))
+  (set-content! ($ "#ans2") (write-to-string (element-content input1)))
+
+  (set-content! ($ "#ans3") (write-to-string (element-read-attribute div1 "class")))
+  (set-content! ($ "#ans4") (write-to-string (element-read-attribute input1 "value")))
+
+  (element-write-attribute! div1 "class" "OK")
+  (set-content! ($ "#ans5") (write-to-string (element-read-attribute div1 "class")))
+  (element-write-attribute! input1 "value" "OK")
+  (set-content! ($ "#ans6") (write-to-string (element-read-attribute input1 "value")))
+
+  (element-empty! div1)
+  (set-content! ($ "#ans7") (write-to-string (get-content div1)))
+  (element-empty! input1)
+  (set-content! ($ "#ans8") (write-to-string (get-content input1)))
+)
+(add-handler! "#button" "click" test)
+        </script>
+
+</body>
+</html>


### PR DESCRIPTION
This PR fixes #212.

## Investigation

- On biwascheme 0.7.1, the embedded jQuery is upgraded form 1.7.1 to 3.5.1
- While `.attr` retrieves the value of an attribute, `.prop` retrieves the value of a property
  - eg. `<input type="text" />` has an attribute "type", a property "type", a property "value" but does not have an attribute "value"
- In jQuery 1.x, `.attr` fallbacks to `.prop` if there is no such attribute. However that of jQuery 3 does not

## Solution

- This patch replaces `.attr` with `.prop` and looks working fine, at least for the attached test.
- Another solution is to add `element-read-property` for `.prop`, but I'd rather keep backward compatibility.