### PR TITLE
Wrap opecodes with class VMCode and class Closure

### DIFF
--- a/demo/repl.html
+++ b/demo/repl.html
@@ -98,8 +98,8 @@ window.bs_eval = function(){
   $("#bs-console").empty();
   var str = $("#bs-input").val();
 
-  var opc = biwascheme.compile(str);
-  var dump = (new BiwaScheme.Dumper()).dump_opc(opc);
+  var vmcode = biwascheme.compile(str);
+  var dump = (new BiwaScheme.Dumper()).dump_opc(vmcode.il);
   $("#bs-opecode").html(dump);
   var before = new Date();
   biwascheme.evaluate(str, function(result){

--- a/src/library/extra_lib.js
+++ b/src/library/extra_lib.js
@@ -260,7 +260,7 @@ define_syntax("define-macro", function(x){
   var opc = Compiler.compile(lambda).il;
   if(opc[2] != 0)
     throw new Bug("you cannot use free variables in macro expander (or define-macro must be on toplevel)")
-  var cls = new Closure([opc[3]]);
+  var cls = new Closure(opc[3], [], -1, undefined);
 
   TopEnv[name.name] = new Syntax(name.name, function(sexp){
     var given_args = sexp.to_array();

--- a/src/library/extra_lib.js
+++ b/src/library/extra_lib.js
@@ -257,7 +257,7 @@ define_syntax("define-macro", function(x){
   }
 
   //["close", <args>, <n>, <body>, <opecodes_next>, <dotpos>]
-  var opc = Compiler.compile(lambda);
+  var opc = Compiler.compile(lambda).il;
   if(opc[2] != 0)
     throw new Bug("you cannot use free variables in macro expander (or define-macro must be on toplevel)")
   var cls = makeClosure([opc[3]]);

--- a/src/library/extra_lib.js
+++ b/src/library/extra_lib.js
@@ -5,12 +5,12 @@ import { define_libfunc, alias_libfunc, define_syntax, define_scmfunc,
          assert_char, assert_symbol, assert_port, assert_pair, assert_list,
          assert_vector,
          assert_function, assert_closure, assert_procedure, assert_date } from "./infra.js"; 
-import { makeClosure } from "../system/_types.js"
 import { to_write, to_display, inspect } from "../system/_writer.js"
 import { write } from "../system/write_ss.js"
 import { Pair, List, array_to_list, deep_array_to_list } from "../system/pair.js"
 import { BiwaSymbol, Sym, gensym } from "../system/symbol.js"
 import Call from "../system/call.js"
+import { Closure } from "../system/closure.js"
 import Compiler from "../system/compiler.js"
 import Console from "../system/console.js"
 import { Bug } from "../system/error.js"
@@ -260,7 +260,7 @@ define_syntax("define-macro", function(x){
   var opc = Compiler.compile(lambda).il;
   if(opc[2] != 0)
     throw new Bug("you cannot use free variables in macro expander (or define-macro must be on toplevel)")
-  var cls = makeClosure([opc[3]]);
+  var cls = new Closure([opc[3]]);
 
   TopEnv[name.name] = new Syntax(name.name, function(sexp){
     var given_args = sexp.to_array();

--- a/src/library/infra.js
+++ b/src/library/infra.js
@@ -1,9 +1,9 @@
 import * as _ from "../deps/underscore-1.10.2-esm.js"
 import { CoreEnv, suppress_deprecation_warning } from "../header.js";
-import { isString, isFunction, isChar, isSymbol, isPort,
-         isVector, isClosure } from "../system/_types.js"
+import { isString, isFunction, isChar, isSymbol, isPort, isVector } from "../system/_types.js"
 import { to_write } from "../system/_writer.js"
 import { make_assert, make_simple_assert } from "../system/assert.js"
+import { isClosure } from "../system/closure.js"
 import { BiwaError } from "../system/error.js"
 import { isHashtable, isMutableHashtable } from "../system/hashtable.js"
 import Interpreter from "../system/interpreter.js"
@@ -113,7 +113,7 @@ const assert_mutable_hashtable = make_simple_assert("mutable hashtable", isMutab
 const assert_promise = make_simple_assert("promise", isPromise);
 
 const assert_function = make_simple_assert("JavaScript function", isFunction);
-const assert_closure = make_simple_assert("scheme function", isClosure);
+const assert_closure = make_simple_assert("scheme closure", isClosure);
 const assert_procedure = make_simple_assert("scheme/js function", function(obj){
   return isClosure(obj) || isFunction(obj);
 });

--- a/src/library/js_interface.js
+++ b/src/library/js_interface.js
@@ -4,8 +4,9 @@ import { define_libfunc, alias_libfunc, define_syntax, define_scmfunc,
          assert_number, assert_integer, assert_real, assert_between, assert_string,
          assert_char, assert_symbol, assert_port, assert_pair, assert_list,
          assert_function, assert_closure, assert_procedure, assert_date, assert, deprecate } from "./infra.js"; 
-import { isSymbol, isClosure } from "../system/_types.js"
+import { isSymbol } from "../system/_types.js"
 import { inspect } from "../system/_writer.js"
+import { isClosure } from "../system/closure.js"
 import { BiwaError } from "../system/error.js"
 import Interpreter from "../system/interpreter.js"
 import { Pair, isList, array_to_list, js_obj_to_alist, alist_to_js_obj } from "../system/pair.js"

--- a/src/library/r6rs_lib.js
+++ b/src/library/r6rs_lib.js
@@ -7,7 +7,7 @@ import { define_libfunc, alias_libfunc, define_syntax, define_scmfunc,
          assert_function, assert_closure, assert_procedure, assert_date, assert, deprecate,
          parse_fraction, parse_integer, parse_float  } from "./infra.js"; 
 import { to_write, to_display, inspect } from "../system/_writer.js"
-import { isNil, isSymbol, isVector, makeClosure, isProcedure,
+import { isNil, isSymbol, isVector, isProcedure,
          eq, eqv, equal, lt } from "../system/_types.js"
 import Call from "../system/call.js"
 import Char from "../system/char.js"

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,7 @@ import BiwaSet from "./system/set.js"
 import { BiwaSymbol, Sym, gensym } from "./system/symbol.js"
 import Syntax from "./system/syntax.js"
 import Values from "./system/values.js"
+import VMCode from "./system/vmcode.js"
 
 import "./library/extra_lib.js"
 import "./library/js_interface.js"
@@ -63,6 +64,7 @@ export default {
   Symbol: BiwaSymbol, Sym, gensym,
   Syntax,
   Values,
+  VMCode,
 
   define_libfunc, define_scmfunc, parse_fraction, is_valid_integer_notation, parse_integer, is_valid_float_notation, parse_float,
 };

--- a/src/main.js
+++ b/src/main.js
@@ -2,12 +2,13 @@ import { TopEnv, CoreEnv, nil, undef, max_trace_size, suppress_deprecation_warni
 import { VERSION, GitCommit } from "./version.js";
 
 import { isNil, isUndef, isBoolean, isString, isFunction, isChar, isSymbol, isPort,
-         isVector, isClosure, makeClosure, isProcedure,
+         isVector, isProcedure,
          isSelfEvaluating, eq, eqv, equal, lt } from "./system/_types.js"
 import { to_write, to_display, inspect } from "./system/_writer.js"
 import { write, write_shared } from "./system/write_ss.js"
 import Call from "./system/call.js"
 import Char from "./system/char.js"
+import { Closure, isClosure } from "./system/closure.js"
 import Compiler from "./system/compiler.js"
 import { Enumeration, isEnumSet } from "./system/enumeration.js"
 import { BiwaError, Bug, UserError } from "./system/error.js"
@@ -41,13 +42,14 @@ export default {
   TopEnv, CoreEnv, nil, undef, max_trace_size, suppress_deprecation_warning,
   Version: VERSION, VERSION, GitCommit,
   isNil, isUndef, isBoolean, isString, isChar, isSymbol, isPort, isPair, isList,
-    isVector, isHashtable, isMutableHashtable, isClosure, makeClosure, isProcedure,
+    isVector, isHashtable, isMutableHashtable, isProcedure,
     isSelfEvaluating, eq, eqv, equal, lt,
   to_write, to_display, inspect,
   write,
   write_ss: write_shared, to_write_ss: write_shared, // For backward compatibility
   Call,
   Char,
+  Closure, isClosure,
   Compiler,
   Enumeration, isEnumSet,
   Error: BiwaError, Bug, UserError,

--- a/src/system/_types.js
+++ b/src/system/_types.js
@@ -7,6 +7,7 @@ import { to_write } from "./_writer.js"
 import Char from "./char.js"
 import { BiwaSymbol } from "./symbol.js"
 import { Port } from "./port.js"
+import { isClosure } from "./closure.js"
 
 const isNil = function(obj){
   return (obj === nil);
@@ -37,18 +38,7 @@ const isPort = function(obj){
 };
 
 const isVector = function(obj){
-  return (obj instanceof Array) && (obj.closure_p !== true);
-};
-
-// Returns true if `obj` is a Scheme closure.
-const isClosure = function(obj){
-  return (obj instanceof Array) && (obj.closure_p === true);
-};
-
-// Change `ary` into a Scheme closure (destructive).
-const makeClosure = function(ary) {
-  ary.closure_p = true;
-  return ary;
+  return (obj instanceof Array);
 };
 
 // procedure: Scheme closure or JavaScript function
@@ -92,5 +82,5 @@ const lt = function(a, b) {
 };
 
 export { isNil, isUndef, isBoolean, isString, isFunction, isChar, isSymbol, isPort,
-         isVector, isClosure, makeClosure, isProcedure,
+         isVector, isProcedure,
          isSelfEvaluating, eq, eqv, equal, lt };

--- a/src/system/_writer.js
+++ b/src/system/_writer.js
@@ -1,6 +1,5 @@
 import * as _ from "../deps/underscore-1.10.2-esm.js"
 import { nil, undef } from "../header.js"
-import { isClosure } from "./_types.js"
 import { BiwaSymbol } from "./symbol.js"
 
 //
@@ -36,8 +35,6 @@ const to_write = function(obj){
               .replace(/\f/g, "\\f")
               .replace(/\r/g, "\\r") +
            '"';
-  else if(isClosure(obj))
-    return "#<Closure>";
   else if(_.isArray(obj))
     return "#(" + _.map(obj, function(e) { return to_write(e); }).join(" ") + ")";
   else if(typeof(obj.to_write) == 'function')

--- a/src/system/closure.js
+++ b/src/system/closure.js
@@ -1,0 +1,22 @@
+import Class from "./class.js"
+
+// A Scheme lambda
+const Closure = Class.create({
+  // il: Intermediate Language (JS array)
+  //     [body, stack[s-1], stack[s-2], .., stack[s-n], dotpos]
+  // expected_args: Expected number of args or `undefined`
+  initialize: function(il, expected_args){
+    this.il = il;
+    this.expected_args = expected_args;
+  },
+
+  to_write: function() {
+    return "#<Closure>";
+  }
+})
+
+const isClosure = function(obj){
+  return (obj instanceof Closure);
+};
+
+export { Closure, isClosure };

--- a/src/system/closure.js
+++ b/src/system/closure.js
@@ -2,11 +2,14 @@ import Class from "./class.js"
 
 // A Scheme lambda
 const Closure = Class.create({
-  // il: Intermediate Language (JS array)
-  //     [body, stack[s-1], stack[s-2], .., stack[s-n], dotpos]
+  // body: Intermediate Language (JS array) 
+  // freevars: Captured free variables
+  // dotpos: The position of `.` in the parameter list. -1 if none
   // expected_args: Expected number of args or `undefined`
-  initialize: function(il, expected_args){
-    this.il = il;
+  initialize: function(body, freevars, dotpos, expected_args){
+    this.body = body;
+    this.freevars = freevars;
+    this.dotpos = dotpos;
     this.expected_args = expected_args;
   },
 

--- a/src/system/compiler.js
+++ b/src/system/compiler.js
@@ -7,6 +7,7 @@ import { Pair, List, isPair, array_to_list } from "./pair.js"
 import BiwaSet from "./set.js"
 import { BiwaSymbol, Sym } from "./symbol.js"
 import Syntax from "./syntax.js"
+import VMCode from "./vmcode.js"
 
 ///
 /// Compiler
@@ -509,7 +510,8 @@ const Compiler = Class.create({
   },
 
   run: function(expr){
-    return this.compile(expr, [new BiwaSet(), new BiwaSet()], new BiwaSet(), new BiwaSet(), ["halt"]);
+    const opc = this.compile(expr, [new BiwaSet(), new BiwaSet()], new BiwaSet(), new BiwaSet(), ["halt"]);
+    return new VMCode(opc);
   }
 });
 

--- a/src/system/interpreter.js
+++ b/src/system/interpreter.js
@@ -477,11 +477,10 @@ const Interpreter = Class.create({
         expr = Compiler.expand(expr);
 
         // compile
-        var opc = this.compiler.run(expr);
-        //Console.p(opc);
+        const vmcode = this.compiler.run(expr);
 
         // execute
-        ret = this._execute(expr, opc, 0, [], 0);
+        ret = this._execute(expr, vmcode.il, 0, [], 0);
       }
 
       if(ret instanceof Pause){ //suspend evaluation

--- a/src/system/vmcode.js
+++ b/src/system/vmcode.js
@@ -1,0 +1,17 @@
+import Class from "./class.js"
+import { isVector } from "./_types.js"
+
+// A compiled Scheme expression
+const VMCode = Class.create({
+  // il: Intermediate Language (JS array)
+  initialize: function(il){
+    if (!isVector(il)) { console.error(il); throw "not array" }
+    this.il = il;
+  },
+
+  to_write: function() {
+    return "#<VMCode>";
+  }
+})
+
+export default VMCode;


### PR DESCRIPTION
This PR fixes #228 and also fixes the last warning not resolved by #211 🎉 

- class `VMCode` wraps intermediate language generated by `Compiler`
- class `Closure` wraps Scheme closure (which is a combination of IL and captured freevars, etc.)