### PR TITLE
fix: `load` on Node should reuse the interpreter

### DIFF
--- a/src/system/parser.js
+++ b/src/system/parser.js
@@ -17,6 +17,11 @@ const Parser = Class.create({
     this.i = 0;
   },
 
+  // Inject scheme program into current position
+  insert: function(txt) {
+    this.tokens.splice(this.i+1, 0, ...this.tokenize(txt));
+  },
+
   inspect: function(){
     return [
       "#<Parser:",


### PR DESCRIPTION
`load` should evaluate the program with the current interpreter
rather than making a new one.

fix #242 