### PR TITLE
fix: (display (js-eval "undefined")) raises error

### DIFF
--- a/src/system/_writer.js
+++ b/src/system/_writer.js
@@ -57,12 +57,12 @@ const to_write = function(obj){
 //
 
 const to_display = function(obj){
-  if(obj.to_display)
-    return obj.to_display(to_display);
   if(_.isUndefined(obj))
     return 'undefined';
   else if(_.isNull(obj))
     return 'null';
+  else if(obj.to_display)
+    return obj.to_display(to_display);
   else if(typeof(obj.valueOf()) == "string")
     return obj;
   else if(obj instanceof BiwaSymbol)


### PR DESCRIPTION
null and undefined cannot have properties

fix #248 