### PR TITLE
[WIP] #229 - remove underscore js as a dependency

### DIFF
--- a/src/library/extra_lib.js
+++ b/src/library/extra_lib.js
@@ -1,33 +1,55 @@
-import * as _ from "../deps/underscore-esm.js"
+import * as _ from "../deps/underscore-esm.js";
 import { TopEnv, nil, undef } from "../header.js";
-import { define_libfunc, alias_libfunc, define_syntax, define_scmfunc,
-         assert_number, assert_integer, assert_real, assert_between, assert_string,
-         assert_char, assert_symbol, assert_port, assert_pair, assert_list,
-         assert_vector,
-         assert_function, assert_closure, assert_procedure, assert_date } from "./infra.js"; 
-import { to_write, to_display, inspect } from "../system/_writer.js"
-import { Pair, List, array_to_list, deep_array_to_list } from "../system/pair.js"
-import { BiwaSymbol, Sym, gensym } from "../system/symbol.js"
-import Call from "../system/call.js"
-import { Closure } from "../system/closure.js"
-import Compiler from "../system/compiler.js"
-import Console from "../system/console.js"
-import { Bug } from "../system/error.js"
-import Interpreter from "../system/interpreter.js"
-import { Port } from "../system/port.js"
-import Syntax from "../system/syntax.js"
+import {
+  define_libfunc,
+  alias_libfunc,
+  define_syntax,
+  define_scmfunc,
+  assert_number,
+  assert_integer,
+  assert_real,
+  assert_between,
+  assert_string,
+  assert_char,
+  assert_symbol,
+  assert_port,
+  assert_pair,
+  assert_list,
+  assert_vector,
+  assert_function,
+  assert_closure,
+  assert_procedure,
+  assert_date,
+} from "./infra.js";
+import { to_write, to_display, inspect } from "../system/_writer.js";
+import {
+  Pair,
+  List,
+  array_to_list,
+  deep_array_to_list,
+} from "../system/pair.js";
+import { BiwaSymbol, Sym, gensym } from "../system/symbol.js";
+import Call from "../system/call.js";
+import { Closure } from "../system/closure.js";
+import Compiler from "../system/compiler.js";
+import Console from "../system/console.js";
+import { Bug } from "../system/error.js";
+import Interpreter from "../system/interpreter.js";
+import { Port } from "../system/port.js";
+import Syntax from "../system/syntax.js";
+import escape from "../system/escape.js";
 
-define_libfunc("html-escape", 1, 1, function(ar){
+define_libfunc("html-escape", 1, 1, function (ar) {
   assert_string(ar[0]);
-  return _.escape(ar[0]);
+  return escape(ar[0]);
 });
-const inspect_objs = function(objs){
-  return _.map(objs, inspect).join(", ");
+const inspect_objs = function (objs) {
+  return objs.map(inspect).join(", ");
 };
-define_libfunc("inspect", 1, null, function(ar){
+define_libfunc("inspect", 1, null, function (ar) {
   return inspect_objs(ar);
 });
-define_libfunc("inspect!", 1, null, function(ar){
+define_libfunc("inspect!", 1, null, function (ar) {
   Console.puts(inspect_objs(ar));
   return undef;
 });
@@ -38,36 +60,38 @@ define_libfunc("inspect!", 1, null, function(ar){
 // json->sexp
 // Array -> list
 // Object -> alist
-// (number, boolean, string, 
+// (number, boolean, string,
 //
-const json2sexp = function(json){
-  switch(true){
-  case _.isNumber(json) ||
-       _.isString(json) ||
-       json === true || json === false:
-    return json;
-  case _.isArray(json):
-    return array_to_list(_.map(json, json2sexp));
-  case typeof(json) == "object":
-    var ls = nil;
-    for(key in json){
-      ls = new Pair(new Pair(key, json2sexp(json[key])),
-             ls);
-    }
-    return ls;
-  default:
-    throw new Error("json->sexp: detected invalid value for json: "+inspect(json));
+const json2sexp = function (json) {
+  switch (true) {
+    case typeof json === "number" ||
+      typeof json === "string" ||
+      json === true ||
+      json === false:
+      return json;
+    case Array.isArray(json):
+      return array_to_list(json.map(json2sexp));
+    case typeof json == "object":
+      var ls = nil;
+      for (key in json) {
+        ls = new Pair(new Pair(key, json2sexp(json[key])), ls);
+      }
+      return ls;
+    default:
+      throw new Error(
+        "json->sexp: detected invalid value for json: " + inspect(json)
+      );
   }
   throw new Bug("must not happen");
-}
-define_libfunc("json->sexp", 1, 1, function(ar){
+};
+define_libfunc("json->sexp", 1, 1, function (ar) {
   return json2sexp(ar[0]);
-})
+});
 
 // (vector-push! v item1 item2 ...)
-define_libfunc("vector-push!", 2, null, function(ar){
+define_libfunc("vector-push!", 2, null, function (ar) {
   assert_vector(ar[0]);
-  for(var i=1; i<ar.length; i++){
+  for (var i = 1; i < ar.length; i++) {
     ar[0].push(ar[i]);
   }
   return ar[0];
@@ -79,86 +103,95 @@ define_libfunc("vector-push!", 2, null, function(ar){
 
 // (identity obj)
 // Returns obj.
-define_libfunc("identity", 1, 1, function(ar){
+define_libfunc("identity", 1, 1, function (ar) {
   return ar[0];
 });
 
 // (inc! i)
 // = (begin (set! i (+ i 1)) i)
 // Increments i (i.e., set i+1 to i).
-define_syntax("inc!", function(x){
+define_syntax("inc!", function (x) {
   var target = x.cdr.car;
-  return List(Sym("begin"),
-              List(Sym("set!"),
-                   target, 
-                   List(Sym("+"), target, 1)),
-              target);
+  return List(
+    Sym("begin"),
+    List(Sym("set!"), target, List(Sym("+"), target, 1)),
+    target
+  );
 });
 
 // (dec! i)
 // = (begin (set! i (- i 1)) i)
 // Decrements i (i.e., set i-1 to i).
-define_syntax("dec!", function(x){
+define_syntax("dec!", function (x) {
   var target = x.cdr.car;
-  return List(Sym("begin"),
-              List(Sym("set!"),
-                   target, 
-                   List(Sym("-"), target, 1)),
-              target);
+  return List(
+    Sym("begin"),
+    List(Sym("set!"), target, List(Sym("-"), target, 1)),
+    target
+  );
 });
 
 // string
 
-define_libfunc("string-concat", 1, 1, function(ar){
+define_libfunc("string-concat", 1, 1, function (ar) {
   assert_list(ar[0]);
   return ar[0].to_array().join("");
-})
+});
 
-define_libfunc("string-split", 2, 2, function(ar){
+define_libfunc("string-split", 2, 2, function (ar) {
   assert_string(ar[0]);
   assert_string(ar[1]);
   return array_to_list(ar[0].split(ar[1]));
-})
+});
 
-define_libfunc("string-join", 1, 2, function(ar){
+define_libfunc("string-join", 1, 2, function (ar) {
   assert_list(ar[0]);
-  var delim = ""
-  if(ar[1]){
+  var delim = "";
+  if (ar[1]) {
     assert_string(ar[1]);
     delim = ar[1];
   }
   return ar[0].to_array().join(delim);
-})
+});
 
 // lists
 
-define_libfunc("intersperse", 2, 2, function(ar){
-  var item = ar[0], ls = ar[1];
+define_libfunc("intersperse", 2, 2, function (ar) {
+  var item = ar[0],
+    ls = ar[1];
   assert_list(ls);
 
   var ret = [];
-  _.each(ls.to_array().reverse(),function(x){
-    ret.push(x);
-    ret.push(item);
-  });
+  ls.to_array()
+    .reverse()
+    .forEach(function (x) {
+      ret.push(x);
+      ret.push(item);
+    });
   ret.pop();
   return array_to_list(ret);
 });
 
-define_libfunc("map-with-index", 2, null, function(ar){
-  var proc = ar.shift(), lists = ar;
-  _.each(lists, assert_list);
+define_libfunc("map-with-index", 2, null, function (ar) {
+  var proc = ar.shift(),
+    lists = ar;
+  lists.forEach(assert_list);
 
-  var results = [], i = 0;
+  var results = [],
+    i = 0;
   return Call.multi_foreach(lists, {
-    call: function(xs){ 
-      var args = _.map(xs, function(x){ return x.car });
+    call: function (xs) {
+      var args = xs.map((x) => x.car);
       args.unshift(i);
       i++;
       return new Call(proc, args);
     },
-    result: function(res){ results.push(res); },
-    finish: function(){ return array_to_list(results); }
+    result: function (res) {
+      results.push(res);
+    },
+    finish: function () {
+      return array_to_list(results);
+    },
   });
 });
 
@@ -171,48 +204,47 @@ define_libfunc("map-with-index", 2, null, function(ar){
 //         (variable 0 (+ variable 1)))
 //        ((>= variable tlimit) result)
 //      body ...)
-define_syntax("dotimes", function(x){
+define_syntax("dotimes", function (x) {
   var spec = x.cdr.car,
-      bodies = x.cdr.cdr;
+    bodies = x.cdr.cdr;
   var variable = spec.car,
-      limit = spec.cdr.car,
-      result = spec.cdr.cdr.car;
+    limit = spec.cdr.car,
+    result = spec.cdr.cdr.car;
   var tlimit = gensym();
 
-  var do_vars = deep_array_to_list([[tlimit, limit],
-                                    [variable, 0, [Sym("+"), variable, 1]]]);
+  var do_vars = deep_array_to_list([
+    [tlimit, limit],
+    [variable, 0, [Sym("+"), variable, 1]],
+  ]);
   var do_check = deep_array_to_list([[Sym(">="), variable, tlimit], result]);
 
-  return new Pair(Sym("do"),
-           new Pair(do_vars,
-             new Pair(do_check,
-               bodies)));
+  return new Pair(Sym("do"), new Pair(do_vars, new Pair(do_check, bodies)));
 });
 
 // sorting (Obsolete: use list-sort, etc. instead of these.)
 
 // utility function. takes a JS Array and a Scheme procedure,
 // returns sorted array
-var sort_with_comp = function(ary, proc, intp){
-  return ary.sort(function(a, b){
-      var intp2 = new Interpreter(intp);
-      return intp2.invoke_closure(proc, [a, b]);
-    });
+var sort_with_comp = function (ary, proc, intp) {
+  return ary.sort(function (a, b) {
+    var intp2 = new Interpreter(intp);
+    return intp2.invoke_closure(proc, [a, b]);
+  });
 };
 
-define_libfunc("list-sort/comp", 1, 2, function(ar, intp){
+define_libfunc("list-sort/comp", 1, 2, function (ar, intp) {
   assert_procedure(ar[0]);
   assert_list(ar[1]);
 
   return array_to_list(sort_with_comp(ar[1].to_array(), ar[0], intp));
 });
-define_libfunc("vector-sort/comp", 1, 2, function(ar, intp){
+define_libfunc("vector-sort/comp", 1, 2, function (ar, intp) {
   assert_procedure(ar[0]);
   assert_vector(ar[1]);
 
-  return sort_with_comp(_.clone(ar[1]), ar[0], intp);
+  return sort_with_comp([...ar[1]], ar[0], intp);
 });
-define_libfunc("vector-sort/comp!", 1, 2, function(ar, intp){
+define_libfunc("vector-sort/comp!", 1, 2, function (ar, intp) {
   assert_procedure(ar[0]);
   assert_vector(ar[1]);
 
@@ -227,9 +259,8 @@ define_libfunc("vector-sort/comp!", 1, 2, function(ar, intp){
 
 var rearrange_args = function (expected, given) {
   var args = [];
-  var dotpos = (new Compiler).find_dot_pos(expected);
-  if (dotpos == -1)
-    args = given;
+  var dotpos = new Compiler().find_dot_pos(expected);
+  if (dotpos == -1) args = given;
   else {
     for (var i = 0; i < dotpos; i++) {
       args[i] = given[i];
@@ -237,19 +268,16 @@ var rearrange_args = function (expected, given) {
     args[i] = array_to_list(given.slice(i));
   }
   return args;
-}
-define_syntax("define-macro", function(x){
+};
+define_syntax("define-macro", function (x) {
   var head = x.cdr.car;
   var expected_args;
-  if(head instanceof Pair){
+  if (head instanceof Pair) {
     var name = head.car;
     expected_args = head.cdr;
     var body = x.cdr.cdr;
-    var lambda = new Pair(Sym("lambda"),
-                   new Pair(expected_args,
-                     body))
-  }
-  else{
+    var lambda = new Pair(Sym("lambda"), new Pair(expected_args, body));
+  } else {
     var name = head;
     var lambda = x.cdr.cdr.car;
     expected_args = lambda.cdr.car;
@@ -257,15 +285,17 @@ define_syntax("define-macro", function(x){
 
   //["close", <args>, <n>, <body>, <opecodes_next>, <dotpos>]
   var opc = Compiler.compile(lambda).il;
-  if(opc[2] != 0)
-    throw new Bug("you cannot use free variables in macro expander (or define-macro must be on toplevel)")
+  if (opc[2] != 0)
+    throw new Bug(
+      "you cannot use free variables in macro expander (or define-macro must be on toplevel)"
+    );
   var cls = new Closure(opc[3], [], -1, undefined);
 
-  TopEnv[name.name] = new Syntax(name.name, function(sexp){
+  TopEnv[name.name] = new Syntax(name.name, function (sexp) {
     var given_args = sexp.to_array();
 
     given_args.shift();
-    
+
     var intp = new Interpreter();
     var args = rearrange_args(expected_args, given_args);
     var result = intp.invoke_closure(cls, args);
@@ -273,71 +303,71 @@ define_syntax("define-macro", function(x){
   });
 
   return undef;
-})
+});
 
-var macroexpand_1 = function(x){
-  if(x instanceof Pair){
+var macroexpand_1 = function (x) {
+  if (x instanceof Pair) {
     // TODO: Should we check CoreEnv too?
-    if(x.car instanceof BiwaSymbol && TopEnv[x.car.name] instanceof Syntax){
+    if (x.car instanceof BiwaSymbol && TopEnv[x.car.name] instanceof Syntax) {
       var transformer = TopEnv[x.car.name];
       x = transformer.transform(x);
-    }
-    else
+    } else
       throw new Error("macroexpand-1: `" + to_write(x) + "' is not a macro");
   }
   return x;
-}
-define_syntax("%macroexpand", function(x){
+};
+define_syntax("%macroexpand", function (x) {
   var expanded = Compiler.expand(x.cdr.car);
   return List(Sym("quote"), expanded);
 });
-define_syntax("%macroexpand-1", function(x){
+define_syntax("%macroexpand-1", function (x) {
   var expanded = macroexpand_1(x.cdr.car);
   return List(Sym("quote"), expanded);
 });
 
-define_libfunc("macroexpand", 1, 1, function(ar){
+define_libfunc("macroexpand", 1, 1, function (ar) {
   return Compiler.expand(ar[0]);
 });
-define_libfunc("macroexpand-1", 1, 1, function(ar){
+define_libfunc("macroexpand-1", 1, 1, function (ar) {
   return macroexpand_1(ar[0]);
 });
 
-define_libfunc("gensym", 0, 0, function(ar){
+define_libfunc("gensym", 0, 0, function (ar) {
   return gensym();
 });
 
 // i/o
 
-define_libfunc("print", 1, null, function(ar){
-  _.map(ar, function(item){
+define_libfunc("print", 1, null, function (ar) {
+  ar.map(function (item) {
     Console.puts(to_display(item), true);
-  })
+  });
   Console.puts(""); //newline
   return undef;
-})
-define_libfunc("write-to-string", 1, 1, function(ar){
+});
+define_libfunc("write-to-string", 1, 1, function (ar) {
   return to_write(ar[0]);
 });
-define_libfunc("read-from-string", 1, 1, function(ar){
+define_libfunc("read-from-string", 1, 1, function (ar) {
   assert_string(ar[0]);
   return Interpreter.read(ar[0]);
 });
-define_libfunc("port-closed?", 1, 1, function(ar){
+define_libfunc("port-closed?", 1, 1, function (ar) {
   assert_port(ar[0]);
-  return !(ar[0].is_open);
+  return !ar[0].is_open;
 });
 //define_libfunc("with-input-from-port", 2, 2, function(ar){
 //define_libfunc("with-error-to-port", 2, 2, function(ar){
-define_libfunc("with-output-to-port", 2, 2, function(ar){
-  var port = ar[0], proc = ar[1];
+define_libfunc("with-output-to-port", 2, 2, function (ar) {
+  var port = ar[0],
+    proc = ar[1];
   assert_port(port);
   assert_procedure(proc);
 
   var original_port = Port.current_output;
-  Port.current_output = port
+  Port.current_output = port;
 
-  return new Call(proc, [port], function(ar){
+  return new Call(proc, [port], function (ar) {
     port.close();
     Port.current_output = original_port;
 
@@ -347,88 +377,87 @@ define_libfunc("with-output-to-port", 2, 2, function(ar){
 
 // syntax
 
-define_syntax("let1", function(x){
-  //(let1 vari expr body ...) 
+define_syntax("let1", function (x) {
+  //(let1 vari expr body ...)
   //=> ((lambda (var) body ...) expr)
-  var vari = x.cdr.car; 
+  var vari = x.cdr.car;
   var expr = x.cdr.cdr.car;
   var body = x.cdr.cdr.cdr;
 
-  return new Pair(new Pair(Sym("lambda"),
-                    new Pair(new Pair(vari, nil),
-                      body)),
-           new Pair(expr, nil));
-})
+  return new Pair(
+    new Pair(Sym("lambda"), new Pair(new Pair(vari, nil), body)),
+    new Pair(expr, nil)
+  );
+});
 
 //
 // Regular Expression
 //
-var assert_regexp = function(obj, fname){
-  if(!(obj instanceof RegExp))
+var assert_regexp = function (obj, fname) {
+  if (!(obj instanceof RegExp))
     throw new Error(fname + ": regexp required, but got " + to_write(obj));
-}
+};
 
-//Function: string->regexp string &keyword case-fold 
-define_libfunc("string->regexp", 1, 1, function(ar){
+//Function: string->regexp string &keyword case-fold
+define_libfunc("string->regexp", 1, 1, function (ar) {
   assert_string(ar[0], "string->regexp");
   return new RegExp(ar[0]); //todo: case-fold
-})
-//Function: regexp? obj 
-define_libfunc("regexp?", 1, 1, function(ar){
-  return (ar[0] instanceof RegExp);
-})
-//Function: regexp->string regexp 
-define_libfunc("regexp->string", 1, 1, function(ar){
+});
+//Function: regexp? obj
+define_libfunc("regexp?", 1, 1, function (ar) {
+  return ar[0] instanceof RegExp;
+});
+//Function: regexp->string regexp
+define_libfunc("regexp->string", 1, 1, function (ar) {
   assert_regexp(ar[0], "regexp->string");
-  return ar[0].toString().slice(1, -1); //cut '/' 
-})
+  return ar[0].toString().slice(1, -1); //cut '/'
+});
 
-define_libfunc("regexp-exec", 2, 2, function(ar){
+define_libfunc("regexp-exec", 2, 2, function (ar) {
   var rexp = ar[0];
-  if(_.isString(ar[0])){
+  if (typeof ar[0] === "string") {
     rexp = new RegExp(ar[0]);
   }
   assert_regexp(rexp, "regexp-exec");
   assert_string(ar[1], "regexp-exec");
-  var ret = rexp.exec(ar[1])
-  return (ret === null) ? false : array_to_list(ret);
-})
+  var ret = rexp.exec(ar[1]);
+  return ret === null ? false : array_to_list(ret);
+});
 
-//  //Function: rxmatch regexp string 
+//  //Function: rxmatch regexp string
 //  define_libfunc("rxmatch", 1, 1, function(ar){
 //    assert_regexp(ar[0], "rxmatch");
 //    assert_string(ar[1], "rxmatch");
 //    return ar[0].match(ar[1]);
 //  });
-//Function: rxmatch-start match &optional (i 0) 
-//Function: rxmatch-end match &optional (i 0) 
-//Function: rxmatch-substring match &optional (i 0) 
-//Function: rxmatch-num-matches match   
-//Function: rxmatch-after match &optional (i 0) 
-//Function: rxmatch-before match &optional (i 0) 
-//Generic application: regmatch &optional index 
-//Generic application: regmatch 'before &optional index 
-//Generic application: regmatch 'after &optional index 
-//Function: regexp-replace regexp string substitution 
+//Function: rxmatch-start match &optional (i 0)
+//Function: rxmatch-end match &optional (i 0)
+//Function: rxmatch-substring match &optional (i 0)
+//Function: rxmatch-num-matches match
+//Function: rxmatch-after match &optional (i 0)
+//Function: rxmatch-before match &optional (i 0)
+//Generic application: regmatch &optional index
+//Generic application: regmatch 'before &optional index
+//Generic application: regmatch 'after &optional index
+//Function: regexp-replace regexp string substitution
 
-// regexp-replace-all regexp string substitution 
-define_libfunc("regexp-replace-all", 3, 3, function(ar){
+// regexp-replace-all regexp string substitution
+define_libfunc("regexp-replace-all", 3, 3, function (ar) {
   var pat = ar[0];
-  if(_.isString(pat)){
-    var rexp = new RegExp(pat, "g")
-  }
-  else{
+  if (typeof pat === "string") {
+    var rexp = new RegExp(pat, "g");
+  } else {
     assert_regexp(pat);
-    var rexp = new RegExp(pat.source, "g")
+    var rexp = new RegExp(pat.source, "g");
   }
   assert_string(ar[1]);
   assert_string(ar[2]);
-  return ar[1].replace(rexp, ar[2])
-})
-//Function: regexp-replace* string rx1 sub1 rx2 sub2 ... 
-//Function: regexp-replace-all* string rx1 sub1 rx2 sub2 ... 
-//Function: regexp-quote string 
-//Macro: rxmatch-let match-expr (var ...) form ... 
-//Macro: rxmatch-if match-expr (var ...) then-form else-form 
-//Macro: rxmatch-cond clause ... 
-//Macro: rxmatch-case string-expr clause ... 
+  return ar[1].replace(rexp, ar[2]);
+});
+//Function: regexp-replace* string rx1 sub1 rx2 sub2 ...
+//Function: regexp-replace-all* string rx1 sub1 rx2 sub2 ...
+//Function: regexp-quote string
+//Macro: rxmatch-let match-expr (var ...) form ...
+//Macro: rxmatch-if match-expr (var ...) then-form else-form
+//Macro: rxmatch-cond clause ...
+//Macro: rxmatch-case string-expr clause ...

--- a/src/library/infra.js
+++ b/src/library/infra.js
@@ -1,17 +1,23 @@
-import * as _ from "../deps/underscore-esm.js"
+import * as _ from "../deps/underscore-esm.js";
 import { CoreEnv, suppress_deprecation_warning } from "../header.js";
-import { isString, isFunction, isSymbol, isPort, isVector } from "../system/_types.js"
-import { to_write } from "../system/_writer.js"
-import { make_assert, make_simple_assert } from "../system/assert.js"
-import { isChar } from "../system/char.js"
-import { isClosure } from "../system/closure.js"
-import { BiwaError } from "../system/error.js"
-import { isHashtable, isMutableHashtable } from "../system/hashtable.js"
-import Interpreter from "../system/interpreter.js"
-import { Complex } from "../system/number.js"
-import { isPair, isList } from "../system/pair.js"
-import { isPromise } from "../system/promise.js"
-import Syntax from "../system/syntax.js"
+import {
+  isString,
+  isFunction,
+  isSymbol,
+  isPort,
+  isVector,
+} from "../system/_types.js";
+import { to_write } from "../system/_writer.js";
+import { make_assert, make_simple_assert } from "../system/assert.js";
+import { isChar } from "../system/char.js";
+import { isClosure } from "../system/closure.js";
+import { BiwaError } from "../system/error.js";
+import { isHashtable, isMutableHashtable } from "../system/hashtable.js";
+import Interpreter from "../system/interpreter.js";
+import { Complex } from "../system/number.js";
+import { isPair, isList } from "../system/pair.js";
+import { isPromise } from "../system/promise.js";
+import Syntax from "../system/syntax.js";
 
 ///
 /// infra.js - Basis for library functions
@@ -20,85 +26,114 @@ import Syntax from "../system/syntax.js"
 //
 // define_*func - define library functions
 //
-const check_arity = function(fname, len, min, max){
-  if(len < min){
-    if(max && max == min)
-      throw new BiwaError(fname+": wrong number of arguments (expected: "+min+" got: "+len+")");
+const check_arity = function (fname, len, min, max) {
+  if (len < min) {
+    if (max && max == min)
+      throw new BiwaError(
+        fname +
+          ": wrong number of arguments (expected: " +
+          min +
+          " got: " +
+          len +
+          ")"
+      );
     else
-      throw new BiwaError(fname+": too few arguments (at least: "+min+" got: "+len+")");
-  }
-  else if(max && max < len)
-    throw new BiwaError(fname+": too many arguments (at most: "+max+" got: "+len+")");
-}
+      throw new BiwaError(
+        fname + ": too few arguments (at least: " + min + " got: " + len + ")"
+      );
+  } else if (max && max < len)
+    throw new BiwaError(
+      fname + ": too many arguments (at most: " + max + " got: " + len + ")"
+    );
+};
 
-const define_libfunc = function(fname, min, max, func){
-  var f = function(ar, intp){
+const define_libfunc = function (fname, min, max, func) {
+  var f = function (ar, intp) {
     check_arity(fname, ar.length, min, max);
     return func(ar, intp);
   };
 
   func["fname"] = fname; // for assert_*
-  f["inspect"] = function(){ return this.fname; }
+  f["inspect"] = function () {
+    return this.fname;
+  };
   CoreEnv[fname] = f;
-}
+};
 
-const alias_libfunc = function(fname, aliases) {
+const alias_libfunc = function (fname, aliases) {
   if (CoreEnv[fname]) {
-    if (_.isArray(aliases)) {
-      _.map(aliases, function(a) { alias_libfunc(fname, a); });
-    } else if (_.isString(aliases)) {
+    if (Array.isArray(aliases)) {
+      aliases.map(function (a) {
+        alias_libfunc(fname, a);
+      });
+    } else if (typeof aliases === "string") {
       CoreEnv[aliases] = CoreEnv[fname];
     } else {
-      console.error("[BUG] bad alias for library function " +
-                    "`" + fname + "': " + aliases.toString());
+      console.error(
+        "[BUG] bad alias for library function " +
+          "`" +
+          fname +
+          "': " +
+          aliases.toString()
+      );
     }
   } else {
-    console.error("[BUG] library function " +
-                  "`" + fname + "'" +
-                  " does not exist, so can't alias it.");
+    console.error(
+      "[BUG] library function " +
+        "`" +
+        fname +
+        "'" +
+        " does not exist, so can't alias it."
+    );
   }
 };
 
-const define_syntax = function(sname, func) {
+const define_syntax = function (sname, func) {
   var s = new Syntax(sname, func);
   CoreEnv[sname] = s;
-}
+};
 
-const define_scmfunc = function(fname, min, max, str){
-  (new Interpreter).evaluate("(define "+fname+" "+str+"\n)");
-}
+const define_scmfunc = function (fname, min, max, str) {
+  new Interpreter().evaluate("(define " + fname + " " + str + "\n)");
+};
 
-//  define_scmfunc("map+", 2, null, 
+//  define_scmfunc("map+", 2, null,
 //    "(lambda (proc ls) (if (null? ls) ls (cons (proc (car ls)) (map proc (cdr ls)))))");
 
 //
 // assertions - type checks
 //
 
-const assert_number = make_simple_assert("number", function(obj){
-  return typeof(obj) == 'number' || (obj instanceof Complex);
+const assert_number = make_simple_assert("number", function (obj) {
+  return typeof obj == "number" || obj instanceof Complex;
 });
 
-const assert_integer = make_simple_assert("integer", function(obj){
-  return typeof(obj) == 'number' && (obj % 1 == 0)
+const assert_integer = make_simple_assert("integer", function (obj) {
+  return typeof obj == "number" && obj % 1 == 0;
 });
 
-const assert_real = make_simple_assert("real number", function(obj){
-  return typeof(obj) == 'number';
+const assert_real = make_simple_assert("real number", function (obj) {
+  return typeof obj == "number";
 });
 
-const assert_between = make_assert(function(fname, obj, from, to){
-  if( typeof(obj) != 'number' || obj != Math.round(obj) ){
-    throw new BiwaError(fname + ": " +
-                               "number required, but got " +
-                               to_write(obj));
+const assert_between = make_assert(function (fname, obj, from, to) {
+  if (typeof obj != "number" || obj != Math.round(obj)) {
+    throw new BiwaError(
+      fname + ": " + "number required, but got " + to_write(obj)
+    );
   }
 
-  if( obj < from || to < obj ){
-    throw new BiwaError(fname + ": " +
-                               "number must be between " +
-                               from + " and " + to + ", but got " +
-                               to_write(obj));
+  if (obj < from || to < obj) {
+    throw new BiwaError(
+      fname +
+        ": " +
+        "number must be between " +
+        from +
+        " and " +
+        to +
+        ", but got " +
+        to_write(obj)
+    );
   }
 });
 
@@ -110,16 +145,21 @@ const assert_pair = make_simple_assert("pair", isPair);
 const assert_list = make_simple_assert("list", isList);
 const assert_vector = make_simple_assert("vector", isVector);
 const assert_hashtable = make_simple_assert("hashtable", isHashtable);
-const assert_mutable_hashtable = make_simple_assert("mutable hashtable", isMutableHashtable); 
+const assert_mutable_hashtable = make_simple_assert(
+  "mutable hashtable",
+  isMutableHashtable
+);
 const assert_promise = make_simple_assert("promise", isPromise);
 
 const assert_function = make_simple_assert("JavaScript function", isFunction);
 const assert_closure = make_simple_assert("scheme closure", isClosure);
-const assert_procedure = make_simple_assert("scheme/js function", function(obj){
+const assert_procedure = make_simple_assert("scheme/js function", function (
+  obj
+) {
   return isClosure(obj) || isFunction(obj);
 });
 
-const assert_date = make_simple_assert("date", function(obj){
+const assert_date = make_simple_assert("date", function (obj) {
   // FIXME: this is not accurate (about cross-frame issue)
   // https://prototype.lighthouseapp.com/projects/8886/tickets/443
   return obj instanceof Date;
@@ -133,9 +173,9 @@ const assert_date = make_simple_assert("date", function(obj){
 //  }
 //});
 
-const assert = make_assert(function(fname, success, message, _fname){
-  if(!success){
-    throw new BiwaError((_fname || fname)+": "+message);
+const assert = make_assert(function (fname, success, message, _fname) {
+  if (!success) {
+    throw new BiwaError((_fname || fname) + ": " + message);
   }
 });
 
@@ -147,12 +187,18 @@ const assert = make_assert(function(fname, success, message, _fname){
 // @param {string} title - feature to be deprecated
 // @param {string} ver - when it will be removed (eg. "1.0")
 // @param {string} alt - alternatives
-const deprecate = function(title, ver, alt){
-  if(suppress_deprecation_warning) return;
+const deprecate = function (title, ver, alt) {
+  if (suppress_deprecation_warning) return;
 
-  var msg = title+" is deprecated and will be removed in BiwaScheme "+ver+ ". "+
-            "Please use "+alt+" instead";
-  console.warn(msg); 
+  var msg =
+    title +
+    " is deprecated and will be removed in BiwaScheme " +
+    ver +
+    ". " +
+    "Please use " +
+    alt +
+    " instead";
+  console.warn(msg);
 };
 
 //
@@ -167,13 +213,12 @@ const deprecate = function(title, ver, alt){
 //
 // @param {string} rep - the string representation of the fraction
 // @return {float|false}
-const parse_fraction = function(rep) {
+const parse_fraction = function (rep) {
   assert_string(rep);
 
-  var frac_parts = rep.split('/');
+  var frac_parts = rep.split("/");
 
-  if (frac_parts.length !== 2)
-    return false;
+  if (frac_parts.length !== 2) return false;
 
   var num_rep = frac_parts[0];
   var denom_rep = frac_parts[1];
@@ -181,11 +226,9 @@ const parse_fraction = function(rep) {
   var num = parse_integer(num_rep, 10);
   var denom = parse_integer(denom_rep, 10);
 
-  if (num === false || denom === false)
-    return false;
+  if (num === false || denom === false) return false;
 
-  if (denom <= 0)
-    return false;
+  if (denom <= 0) return false;
 
   return num / denom;
 };
@@ -196,17 +239,16 @@ const parse_fraction = function(rep) {
 // @param {string} rep - the string representation of the integer
 // @param {integer} rdx - the radix, where 2 <= rdx <= 36
 // @return {boolean}
-const is_valid_integer_notation = function(rep, rdx) {
+const is_valid_integer_notation = function (rep, rdx) {
   assert_string(rep);
   assert_integer(rdx);
 
-  if (rdx < 2 || rdx > 36)
-    return false;
+  if (rdx < 2 || rdx > 36) return false;
 
-  var rdx_symbols = '0123456789abcdefghijklmnopqrstuvwxyz';
+  var rdx_symbols = "0123456789abcdefghijklmnopqrstuvwxyz";
 
   var valid_symbols = rdx_symbols.slice(0, rdx);
-  var sym_regex = new RegExp('^[+-]?' + '[' + valid_symbols + ']+$', 'ig');
+  var sym_regex = new RegExp("^[+-]?" + "[" + valid_symbols + "]+$", "ig");
 
   return sym_regex.test(rep);
 };
@@ -218,20 +260,17 @@ const is_valid_integer_notation = function(rep, rdx) {
 // @param {string} rep - the string representation of the integer
 // @param {integer} rdx - the radix, where 2 <= rdx <= 36
 // @return {integer|false}
-const parse_integer = function(rep, rdx) {
+const parse_integer = function (rep, rdx) {
   assert_string(rep);
   assert_integer(rdx);
 
-  if (rdx < 2 || rdx > 36)
-    return false;
+  if (rdx < 2 || rdx > 36) return false;
 
-  if (!is_valid_integer_notation(rep, rdx))
-    return false;
+  if (!is_valid_integer_notation(rep, rdx)) return false;
 
   var res = parseInt(rep, rdx);
 
-  if (Number.isNaN(res))
-    return false;
+  if (Number.isNaN(res)) return false;
 
   return res;
 };
@@ -250,14 +289,13 @@ const parse_integer = function(rep, rdx) {
 //
 // @param {string} rep - the string representation of the float.
 // @return {boolean}
-const is_valid_float_notation = function(rep) {
+const is_valid_float_notation = function (rep) {
   assert_string(rep);
 
   var sci_regex = /^[+-]?[0-9]+[.]?[0-9]*e[+-]?[0-9]+$/i;
-  var fp_regex  = /(^[+-]?[0-9]*[.][0-9]+$)|(^[+-]?[0-9]+[.][0-9]*$)/;
+  var fp_regex = /(^[+-]?[0-9]*[.][0-9]+$)|(^[+-]?[0-9]+[.][0-9]*$)/;
 
-  if (sci_regex.test(rep) || fp_regex.test(rep))
-    return true;
+  if (sci_regex.test(rep) || fp_regex.test(rep)) return true;
 
   return is_valid_integer_notation(rep, 10);
 };
@@ -268,26 +306,48 @@ const is_valid_float_notation = function(rep) {
 //
 // @param {string} rep - the string representation of the floating-point value
 // @return {float|false}
-const parse_float = function(rep) {
+const parse_float = function (rep) {
   assert_string(rep);
 
-  if (!is_valid_float_notation(rep))
-    return false;
+  if (!is_valid_float_notation(rep)) return false;
 
   var res = new Number(rep).valueOf();
 
-  if (Number.isNaN(res))
-    return false;
+  if (Number.isNaN(res)) return false;
 
-  if (!Number.isFinite(res))
-    return false;
+  if (!Number.isFinite(res)) return false;
 
   return res;
 };
 
-export { define_libfunc, alias_libfunc, define_syntax, define_scmfunc,
-         assert_number, assert_integer, assert_real, assert_between, assert_string,
-         assert_char, assert_symbol, assert_port, assert_pair, assert_list,
-         assert_vector, assert_hashtable, assert_mutable_hashtable, assert_promise,
-         assert_function, assert_closure, assert_procedure, assert_date, assert, deprecate,
-         parse_fraction, is_valid_integer_notation, parse_integer, is_valid_float_notation, parse_float }; 
+export {
+  define_libfunc,
+  alias_libfunc,
+  define_syntax,
+  define_scmfunc,
+  assert_number,
+  assert_integer,
+  assert_real,
+  assert_between,
+  assert_string,
+  assert_char,
+  assert_symbol,
+  assert_port,
+  assert_pair,
+  assert_list,
+  assert_vector,
+  assert_hashtable,
+  assert_mutable_hashtable,
+  assert_promise,
+  assert_function,
+  assert_closure,
+  assert_procedure,
+  assert_date,
+  assert,
+  deprecate,
+  parse_fraction,
+  is_valid_integer_notation,
+  parse_integer,
+  is_valid_float_notation,
+  parse_float,
+};

--- a/src/library/js_interface.js
+++ b/src/library/js_interface.js
@@ -1,17 +1,41 @@
-import * as _ from "../deps/underscore-esm.js"
+import * as _ from "../deps/underscore-esm.js";
 import { nil, undef } from "../header.js";
-import { define_libfunc, alias_libfunc, define_syntax, define_scmfunc,
-         assert_number, assert_integer, assert_real, assert_between, assert_string,
-         assert_char, assert_symbol, assert_port, assert_pair, assert_list,
-         assert_function, assert_closure, assert_procedure, assert_date, assert, deprecate } from "./infra.js"; 
-import { isSymbol } from "../system/_types.js"
-import { inspect } from "../system/_writer.js"
-import { isClosure } from "../system/closure.js"
-import { BiwaError } from "../system/error.js"
-import Interpreter from "../system/interpreter.js"
-import { Pair, isList, array_to_list, js_obj_to_alist, alist_to_js_obj } from "../system/pair.js"
-import Pause from "../system/pause.js"
-import { BiwaSymbol, Sym } from "../system/symbol.js"
+import {
+  define_libfunc,
+  alias_libfunc,
+  define_syntax,
+  define_scmfunc,
+  assert_number,
+  assert_integer,
+  assert_real,
+  assert_between,
+  assert_string,
+  assert_char,
+  assert_symbol,
+  assert_port,
+  assert_pair,
+  assert_list,
+  assert_function,
+  assert_closure,
+  assert_procedure,
+  assert_date,
+  assert,
+  deprecate,
+} from "./infra.js";
+import { isSymbol } from "../system/_types.js";
+import { inspect } from "../system/_writer.js";
+import { isClosure } from "../system/closure.js";
+import { BiwaError } from "../system/error.js";
+import Interpreter from "../system/interpreter.js";
+import {
+  Pair,
+  isList,
+  array_to_list,
+  js_obj_to_alist,
+  alist_to_js_obj,
+} from "../system/pair.js";
+import Pause from "../system/pause.js";
+import { BiwaSymbol, Sym } from "../system/symbol.js";
 
 //
 // interface to javascript
@@ -21,26 +45,25 @@ import { BiwaSymbol, Sym } from "../system/symbol.js"
 // See: https://github.com/rollup/rollup/wiki/Troubleshooting#avoiding-eval
 let eval2 = eval;
 
-define_libfunc("js-eval", 1, 1, function(ar){
+define_libfunc("js-eval", 1, 1, function (ar) {
   return eval2(ar[0]);
 });
-define_libfunc("js-ref", 2, 2, function(ar){
-  if(_.isString(ar[1])){
+define_libfunc("js-ref", 2, 2, function (ar) {
+  if (typeof ar[1] === "string") {
     return ar[0][ar[1]];
-  }
-  else{
+  } else {
     assert_symbol(ar[1]);
     return ar[0][ar[1].name];
   }
 });
-define_libfunc("js-set!", 3, 3, function(ar){
+define_libfunc("js-set!", 3, 3, function (ar) {
   assert_string(ar[1]);
   ar[0][ar[1]] = ar[2];
   return undef;
 });
 
 // (js-call (js-eval "Math.pow") 2 4)
-define_libfunc("js-call", 1, null, function(ar){
+define_libfunc("js-call", 1, null, function (ar) {
   var js_func = ar.shift();
   assert_function(js_func);
 
@@ -48,17 +71,15 @@ define_libfunc("js-call", 1, null, function(ar){
   return js_func.apply(receiver, ar);
 });
 // (js-invoke (js-new "Date") "getTime")
-define_libfunc("js-invoke", 2, null, function(ar){
+define_libfunc("js-invoke", 2, null, function (ar) {
   var js_obj = ar.shift();
   var func_name = ar.shift();
-  if(!_.isString(func_name)){
+  if (!(typeof func_name === "string")) {
     assert_symbol(func_name);
     func_name = func_name.name;
   }
-  if(js_obj[func_name])
-    return js_obj[func_name].apply(js_obj, ar);
-  else
-    throw new Error("js-invoke: function "+func_name+" is not defined");
+  if (js_obj[func_name]) return js_obj[func_name].apply(js_obj, ar);
+  else throw new Error("js-invoke: function " + func_name + " is not defined");
 });
 
 // Short hand for JavaScript method call.
@@ -76,64 +97,64 @@ define_libfunc("js-invoke", 2, null, function(ar){
 //   '((a . b) (c . 4)) to
 //   {a: "b", c: 4}
 //
-define_libfunc("js-invocation", 2, null, function(ar, intp){
+define_libfunc("js-invocation", 2, null, function (ar, intp) {
   var receiver = ar.shift();
-  // TODO: convert lambdas by js-closure 
-  if(isSymbol(receiver)){
+  // TODO: convert lambdas by js-closure
+  if (isSymbol(receiver)) {
     receiver = eval2(receiver.name); //XXX: is this ok?
   }
 
   var v = receiver;
 
   // Process each method call
-  _.each(ar, function(callspec){
-      if(isSymbol(callspec)){
-        // Property access
-        v = v[callspec.name];
-      }
-      else if(isList(callspec)){
-        // Method call
-        var args = callspec.to_array();
+  ar.forEach(function (callspec) {
+    if (isSymbol(callspec)) {
+      // Property access
+      v = v[callspec.name];
+    } else if (isList(callspec)) {
+      // Method call
+      var args = callspec.to_array();
 
-        assert_symbol(args[0]);
-        var method = args.shift().name;
+      assert_symbol(args[0]);
+      var method = args.shift().name;
 
-        // Convert arguments
-        args = _.map(args, function(arg){
-            if(isClosure(arg)){
-              // closure -> JavaScript funciton
-              return js_closure(arg, intp);
-            }
-            else if(isList(arg)){
-              // alist -> JavaScript Object
-              var o = {};
-              arg.foreach(function(pair){
-                  assert_symbol(pair.car);
-                  o[pair.car.name] = pair.cdr;
-                });
-              return o;
-            }
-            else
-              return arg;
+      // Convert arguments
+      args = args.map(function (arg) {
+        if (isClosure(arg)) {
+          // closure -> JavaScript funciton
+          return js_closure(arg, intp);
+        } else if (isList(arg)) {
+          // alist -> JavaScript Object
+          var o = {};
+          arg.foreach(function (pair) {
+            assert_symbol(pair.car);
+            o[pair.car.name] = pair.cdr;
           });
+          return o;
+        } else return arg;
+      });
 
-        // Call the method
-        if(!_.isFunction(v[method])){
-          throw new BiwaError("js-invocation: the method `"+method+"' not found");
-        }
-        v = v[method].apply(v, args);
+      // Call the method
+      if (!(typeof v[method] === "function")) {
+        throw new BiwaError(
+          "js-invocation: the method `" + method + "' not found"
+        );
       }
-      else{
-        // (wrong argument)
-        throw new BiwaError("js-invocation: expected list or symbol for callspec but got " + inspect(callspec));
-      }
-    });
+      v = v[method].apply(v, args);
+    } else {
+      // (wrong argument)
+      throw new BiwaError(
+        "js-invocation: expected list or symbol for callspec but got " +
+          inspect(callspec)
+      );
+    }
+  });
 
   return v;
 });
 
-// TODO: provide corresponding macro ".." 
-define_syntax("..", function(x){
+// TODO: provide corresponding macro ".."
+define_syntax("..", function (x) {
   if (x.cdr == nil) {
     throw new Error("malformed ..");
   }
@@ -142,24 +163,24 @@ define_syntax("..", function(x){
 
 // (js-new (js-eval "Date") 2005 1 1)
 // (js-new (js-eval "Draggable") elem 'onEnd (lambda (drg) ...))
-//   If symbol is given, following arguments are converted to 
+//   If symbol is given, following arguments are converted to
 //   an js object. If any of them is a scheme closure,
 //   it is converted to js function which invokes that closure.
 //
 // (js-new "Date" 2005 1 1)
 //   You can pass javascript program string for constructor.
-define_libfunc("js-new", 1, null, function(ar, intp){
+define_libfunc("js-new", 1, null, function (ar, intp) {
   // make js object from key-value pair
-  var array_to_obj = function(ary){
-    if((ary.length % 2) != 0)
+  var array_to_obj = function (ary) {
+    if (ary.length % 2 != 0)
       throw new Error("js-new: odd number of key-value pair");
 
     var obj = {};
-    for(var i=0; i<ary.length; i+=2){
-      var key = ary[i], value = ary[i+1];
+    for (var i = 0; i < ary.length; i += 2) {
+      var key = ary[i],
+        value = ary[i + 1];
       assert_symbol(key);
-      if(isClosure(value))
-        value = js_closure(value, intp);
+      if (isClosure(value)) value = js_closure(value, intp);
 
       obj[key.name] = value;
     }
@@ -167,20 +188,18 @@ define_libfunc("js-new", 1, null, function(ar, intp){
   };
 
   var ctor = ar.shift();
-  if (_.isString(ctor)) ctor = eval2(ctor);
+  if (typeof ctor === "string") ctor = eval2(ctor);
 
-  if(ar.length == 0){
+  if (ar.length == 0) {
     return new ctor();
-  }
-  else{
+  } else {
     // pack args to js object, if symbol appears
     var args = [];
-    for(var i=0; i<ar.length; i++){
-      if(ar[i] instanceof BiwaSymbol){
+    for (var i = 0; i < ar.length; i++) {
+      if (ar[i] instanceof BiwaSymbol) {
         args.push(array_to_obj(ar.slice(i)));
         break;
-      }
-      else{
+      } else {
         args.push(ar[i]);
       }
     }
@@ -191,23 +210,23 @@ define_libfunc("js-new", 1, null, function(ar, intp){
 
 // (js-obj "foo" 1 "bar" 2)
 // -> {"foo": 1, "bar": 2}
-define_libfunc("js-obj", 0, null, function(ar){
-  if(ar.length % 2 != 0){
+define_libfunc("js-obj", 0, null, function (ar) {
+  if (ar.length % 2 != 0) {
     throw new Error("js-obj: number of arguments must be even");
   }
 
   var obj = {};
-  for(let i=0; i<ar.length/2; i++){
-    assert_string(ar[i*2]);
-    obj[ar[i*2]] = ar[i*2+1];
+  for (let i = 0; i < ar.length / 2; i++) {
+    assert_string(ar[i * 2]);
+    obj[ar[i * 2]] = ar[i * 2 + 1];
   }
   return obj;
 });
 
-const js_closure = function(proc, intp){
+const js_closure = function (proc, intp) {
   var intp2 = new Interpreter(intp);
-  return function(/*args*/){
-    return intp2.invoke_closure(proc, _.toArray(arguments));
+  return function (/*args*/) {
+    return intp2.invoke_closure(proc, Array.from(arguments));
   };
 };
 // (js-closure (lambda (event) ..))
@@ -215,87 +234,95 @@ const js_closure = function(proc, intp){
 //
 // Example
 //   (add-handler! ($ "#btn") "click" (js-closure on-click))
-define_libfunc("js-closure", 1, 1, function(ar, intp){
+define_libfunc("js-closure", 1, 1, function (ar, intp) {
   assert_closure(ar[0]);
   return js_closure(ar[0], intp);
 });
 
-define_libfunc("js-null?", 1, 1, function(ar){
+define_libfunc("js-null?", 1, 1, function (ar) {
   return ar[0] === null;
 });
 
-define_libfunc("js-undefined?", 1, 1, function(ar){
+define_libfunc("js-undefined?", 1, 1, function (ar) {
   return ar[0] === undefined;
 });
 
-define_libfunc("js-function?", 1, 1, function(ar){
-  return _.isFunction(ar[0]);
+define_libfunc("js-function?", 1, 1, function (ar) {
+  return typeof ar[0] === "function";
 });
 
-define_libfunc("js-array-to-list", 1, 1, function(ar){
+define_libfunc("js-array-to-list", 1, 1, function (ar) {
   deprecate("js-array-to-list", "1.0", "js-array->list");
   return array_to_list(ar[0]);
 });
 
-define_libfunc("js-array->list", 1, 1, function(ar){
+define_libfunc("js-array->list", 1, 1, function (ar) {
   return array_to_list(ar[0]);
 });
 
-define_libfunc("list-to-js-array", 1, 1, function(ar){
+define_libfunc("list-to-js-array", 1, 1, function (ar) {
   deprecate("list-to-js-array", "1.0", "list->js-array");
   return ar[0].to_array();
 });
 
-define_libfunc("list->js-array", 1, 1, function(ar){
+define_libfunc("list->js-array", 1, 1, function (ar) {
   return ar[0].to_array();
 });
 
-define_libfunc("alist-to-js-obj", 1, 1, function(ar) {
+define_libfunc("alist-to-js-obj", 1, 1, function (ar) {
   deprecate("alist-to-js-obj", "1.0", "alist->js-obj");
   return alist_to_js_obj(ar[0]);
 });
 
-define_libfunc("alist->js-obj", 1, 1, function(ar) {
+define_libfunc("alist->js-obj", 1, 1, function (ar) {
   assert_list(ar[0]);
   return alist_to_js_obj(ar[0]);
 });
 
-define_libfunc("js-obj-to-alist", 1, 1, function(ar) {
+define_libfunc("js-obj-to-alist", 1, 1, function (ar) {
   deprecate("js-obj-to-alist", "1.0", "js-obj->alist");
   return js_obj_to_alist(ar[0]);
 });
-define_libfunc("js-obj->alist", 1, 1, function(ar) {
+define_libfunc("js-obj->alist", 1, 1, function (ar) {
   return js_obj_to_alist(ar[0]);
 });
 
 //
 // timer, sleep
 //
-define_libfunc("timer", 2, 2, function(ar, intp){
-  var proc = ar[0], sec = ar[1];
+define_libfunc("timer", 2, 2, function (ar, intp) {
+  var proc = ar[0],
+    sec = ar[1];
   assert_closure(proc);
   assert_real(sec);
   var intp2 = new Interpreter(intp);
-  setTimeout(function(){ intp2.invoke_closure(proc); }, sec * 1000);
+  setTimeout(function () {
+    intp2.invoke_closure(proc);
+  }, sec * 1000);
   return undef;
 });
-define_libfunc("set-timer!", 2, 2, function(ar, intp){
-  var proc = ar[0], sec = ar[1];
+define_libfunc("set-timer!", 2, 2, function (ar, intp) {
+  var proc = ar[0],
+    sec = ar[1];
   assert_closure(proc);
   assert_real(sec);
   var intp2 = new Interpreter(intp);
-  return setInterval(function(){ intp2.invoke_closure(proc); }, sec * 1000);
+  return setInterval(function () {
+    intp2.invoke_closure(proc);
+  }, sec * 1000);
 });
-define_libfunc("clear-timer!", 1, 1, function(ar){
+define_libfunc("clear-timer!", 1, 1, function (ar) {
   var timer_id = ar[0];
   clearInterval(timer_id);
   return undef;
 });
-define_libfunc("sleep", 1, 1, function(ar){
+define_libfunc("sleep", 1, 1, function (ar) {
   var sec = ar[0];
   assert_real(sec);
-  return new Pause(function(pause){
-    setTimeout(function(){ pause.resume(nil); }, sec * 1000);
+  return new Pause(function (pause) {
+    setTimeout(function () {
+      pause.resume(nil);
+    }, sec * 1000);
   });
 });
 
@@ -312,13 +339,11 @@ define_libfunc("sleep", 1, 1, function(ar){
 //
 // Example:
 //     (some-func arg1 (console-debug arg2) arg3)
-var define_console_func = function(name){
-  define_libfunc("console-"+name, 1, null, function(ar){
+var define_console_func = function (name) {
+  define_libfunc("console-" + name, 1, null, function (ar) {
     var con = window.console;
-    if(con){
-      var vals = _.map(ar, function(item){
-        return inspect(item, {fallback: item});
-      });
+    if (con) {
+      var vals = ar.map((item) => inspect(item, { fallback: item }));
 
       con[name].apply(con, vals);
     }
@@ -330,4 +355,3 @@ define_console_func("log");
 define_console_func("info");
 define_console_func("warn");
 define_console_func("error");
-

--- a/src/library/r6rs_lib.js
+++ b/src/library/r6rs_lib.js
@@ -1,27 +1,84 @@
-import * as _ from "../deps/underscore-esm.js"
+import * as _ from "../deps/underscore-esm.js";
 import { TopEnv, CoreEnv, nil, undef } from "../header.js";
-import { define_libfunc, alias_libfunc, define_syntax, define_scmfunc,
-         assert_number, assert_integer, assert_real, assert_between, assert_string,
-         assert_char, assert_symbol, assert_port, assert_pair, assert_list,
-         assert_vector, assert_hashtable, assert_mutable_hashtable, assert_promise,
-         assert_function, assert_closure, assert_procedure, assert_date, assert, deprecate,
-         parse_fraction, parse_integer, parse_float  } from "./infra.js"; 
-import { eq, eqv, equal } from "../system/_equality.js"
-import { to_write, to_display, inspect, write_shared, write_simple } from "../system/_writer.js"
-import { isNil, isSymbol, isVector, isProcedure, lt } from "../system/_types.js"
-import Call from "../system/call.js"
-import { Char } from "../system/char.js"
-import { Bug, BiwaError, UserError } from "../system/error.js"
-import { Enumeration, assert_enum_set } from "../system/enumeration.js"
-import { Hashtable } from "../system/hashtable.js"
-import Interpreter from "../system/interpreter.js"
-import { Complex, Rational, isNumber, isComplex, isReal, isRational, isInteger } from "../system/number.js"
-import { Pair, List, isPair, isList, array_to_list, deep_array_to_list, Cons } from "../system/pair.js"
-import { Port, eof } from "../system/port.js"
-import { BiwaPromise } from "../system/promise.js"
-import { Record, isRecord, assert_record, assert_record_td, assert_record_cd } from "../system/record.js"
-import { BiwaSymbol, Sym, gensym } from "../system/symbol.js"
-import Values from "../system/values.js"
+import {
+  define_libfunc,
+  alias_libfunc,
+  define_syntax,
+  define_scmfunc,
+  assert_number,
+  assert_integer,
+  assert_real,
+  assert_between,
+  assert_string,
+  assert_char,
+  assert_symbol,
+  assert_port,
+  assert_pair,
+  assert_list,
+  assert_vector,
+  assert_hashtable,
+  assert_mutable_hashtable,
+  assert_promise,
+  assert_function,
+  assert_closure,
+  assert_procedure,
+  assert_date,
+  assert,
+  deprecate,
+  parse_fraction,
+  parse_integer,
+  parse_float,
+} from "./infra.js";
+import { eq, eqv, equal } from "../system/_equality.js";
+import {
+  to_write,
+  to_display,
+  inspect,
+  write_shared,
+  write_simple,
+} from "../system/_writer.js";
+import {
+  isNil,
+  isSymbol,
+  isVector,
+  isProcedure,
+  lt,
+} from "../system/_types.js";
+import Call from "../system/call.js";
+import { Char } from "../system/char.js";
+import { Bug, BiwaError, UserError } from "../system/error.js";
+import { Enumeration, assert_enum_set } from "../system/enumeration.js";
+import { Hashtable } from "../system/hashtable.js";
+import Interpreter from "../system/interpreter.js";
+import {
+  Complex,
+  Rational,
+  isNumber,
+  isComplex,
+  isReal,
+  isRational,
+  isInteger,
+} from "../system/number.js";
+import {
+  Pair,
+  List,
+  isPair,
+  isList,
+  array_to_list,
+  deep_array_to_list,
+  Cons,
+} from "../system/pair.js";
+import { Port, eof } from "../system/port.js";
+import { BiwaPromise } from "../system/promise.js";
+import {
+  Record,
+  isRecord,
+  assert_record,
+  assert_record_td,
+  assert_record_cd,
+} from "../system/record.js";
+import { BiwaSymbol, Sym, gensym } from "../system/symbol.js";
+import Values from "../system/values.js";
 
 ///
 /// R6RS Base library
@@ -40,154 +97,157 @@ import Values from "../system/values.js"
 //(set!)
 //            11.4.5  Derived conditionaar
 
-define_syntax("cond", function(x){
+define_syntax("cond", function (x) {
   var clauses = x.cdr;
-  if(!(clauses instanceof Pair) || clauses === nil){
-    throw new BiwaError("malformed cond: cond needs list but got " +
-                    write_ss(clauses));
+  if (!(clauses instanceof Pair) || clauses === nil) {
+    throw new BiwaError(
+      "malformed cond: cond needs list but got " + write_ss(clauses)
+    );
   }
   // TODO: assert that clauses is a proper list
 
   var ret = null;
-  _.each(clauses.to_array().reverse(), function(clause){
-    if(!(clause instanceof Pair)){
-      throw new BiwaError("bad clause in cond: " + write_ss(clause));
-    }
+  clauses
+    .to_array()
+    .reverse()
+    .forEach(function (clause) {
+      if (!(clause instanceof Pair)) {
+        throw new BiwaError("bad clause in cond: " + write_ss(clause));
+      }
 
-    if(clause.car === Sym("else")){
-      if(ret !== null){
-        throw new BiwaError("'else' clause of cond followed by more clauses: " +
-                        write_ss(clauses));
-      }
-      else if(clause.cdr === nil){
-        // pattern A: (else)
-        //  -> #f            ; not specified in R6RS...?
-        ret = false;
-      }
-      else if(clause.cdr.cdr === nil){
-        // pattern B: (else expr)
-        //  -> expr
-        ret = clause.cdr.car;
-      }
-      else{
-        // pattern C: (else expr ...)
-        //  -> (begin expr ...)
-        ret = new Pair(Sym("begin"), clause.cdr);
-      }
-    }
-    else{
-      var test = clause.car;
-      if(clause.cdr === nil){
-        // pattern 1: (test)
-        //  -> (or test ret)
-        ret = List(Sym("or"), test, ret);
-      }
-      else if (clause.cdr.cdr === nil){
-        // pattern 2: (test expr)
-        //  -> (if test expr ret)
-        ret = List(Sym("if"), test, clause.cdr.car, ret);
-      }
-      else if(clause.cdr.car === Sym("=>")){
-        // pattern 3: (test => expr)
-        //  -> (let ((#<gensym1> test))
-        //       (if test (expr #<gensym1>) ret))
-        var test = clause.car, expr = clause.cdr.cdr.car;
-        var tmp_sym = gensym();
+      if (clause.car === Sym("else")) {
+        if (ret !== null) {
+          throw new BiwaError(
+            "'else' clause of cond followed by more clauses: " +
+              write_ss(clauses)
+          );
+        } else if (clause.cdr === nil) {
+          // pattern A: (else)
+          //  -> #f            ; not specified in R6RS...?
+          ret = false;
+        } else if (clause.cdr.cdr === nil) {
+          // pattern B: (else expr)
+          //  -> expr
+          ret = clause.cdr.car;
+        } else {
+          // pattern C: (else expr ...)
+          //  -> (begin expr ...)
+          ret = new Pair(Sym("begin"), clause.cdr);
+        }
+      } else {
+        var test = clause.car;
+        if (clause.cdr === nil) {
+          // pattern 1: (test)
+          //  -> (or test ret)
+          ret = List(Sym("or"), test, ret);
+        } else if (clause.cdr.cdr === nil) {
+          // pattern 2: (test expr)
+          //  -> (if test expr ret)
+          ret = List(Sym("if"), test, clause.cdr.car, ret);
+        } else if (clause.cdr.car === Sym("=>")) {
+          // pattern 3: (test => expr)
+          //  -> (let ((#<gensym1> test))
+          //       (if test (expr #<gensym1>) ret))
+          var test = clause.car,
+            expr = clause.cdr.cdr.car;
+          var tmp_sym = gensym();
 
-        ret = List(Sym("let"),
-                   List( List(tmp_sym, test) ),
-                   List(Sym("if"), test, List(expr, tmp_sym), ret));
+          ret = List(
+            Sym("let"),
+            List(List(tmp_sym, test)),
+            List(Sym("if"), test, List(expr, tmp_sym), ret)
+          );
+        } else {
+          // pattern 4: (test expr ...)
+          //  -> (if test (begin expr ...) ret)
+          ret = List(Sym("if"), test, new Pair(Sym("begin"), clause.cdr), ret);
+        }
       }
-      else{
-        // pattern 4: (test expr ...)
-        //  -> (if test (begin expr ...) ret)
-        ret = List(Sym("if"), test,
-                   new Pair(Sym("begin"), clause.cdr),
-                   ret);
-      }
-    }
-  });
+    });
   return ret;
 });
 
-define_syntax("case", function(x){
+define_syntax("case", function (x) {
   var tmp_sym = gensym();
 
-  if(x.cdr === nil){
+  if (x.cdr === nil) {
     throw new BiwaError("case: at least one clause is required");
-  }
-  else if(!(x.cdr instanceof Pair)){
+  } else if (!(x.cdr instanceof Pair)) {
     throw new BiwaError("case: proper list is required");
-  }
-  else{
+  } else {
     // (case key clauses ....)
     //  -> (let ((#<gensym1> key))
     var key = x.cdr.car;
     var clauses = x.cdr.cdr;
 
     var ret = undefined;
-    _.each(clauses.to_array().reverse(), function(clause){
-      if(clause.car === Sym("else")){
-        // pattern 0: (else expr ...)
-        //  -> (begin expr ...)
-        if(ret === undefined){
-          ret = new Pair(Sym("begin"), clause.cdr);
+    clauses
+      .to_array()
+      .reverse()
+      .forEach(function (clause) {
+        if (clause.car === Sym("else")) {
+          // pattern 0: (else expr ...)
+          //  -> (begin expr ...)
+          if (ret === undefined) {
+            ret = new Pair(Sym("begin"), clause.cdr);
+          } else {
+            throw new BiwaError(
+              "case: 'else' clause followed by more clauses: " +
+                write_ss(clauses)
+            );
+          }
+        } else {
+          // pattern 1: ((datum ...) expr ...)
+          //  -> (if (or (eqv? key (quote d1)) ...) (begin expr ...) ret)
+          ret = List(
+            Sym("if"),
+            new Pair(
+              Sym("or"),
+              array_to_list(
+                _.map(clause.car.to_array(), function (d) {
+                  return List(Sym("eqv?"), tmp_sym, List(Sym("quote"), d));
+                })
+              )
+            ),
+            new Pair(Sym("begin"), clause.cdr),
+            ret
+          );
         }
-        else{
-          throw new BiwaError("case: 'else' clause followed by more clauses: " +
-                          write_ss(clauses));
-        }
-      }
-      else{
-        // pattern 1: ((datum ...) expr ...)
-        //  -> (if (or (eqv? key (quote d1)) ...) (begin expr ...) ret)
-        ret = List(
-          Sym("if"),
-          new Pair(Sym("or"), array_to_list(_.map(clause.car.to_array(), function(d){
-              return List(Sym("eqv?"),
-                          tmp_sym,
-                          List(Sym("quote"), d));
-          }))),
-          new Pair(Sym("begin"), clause.cdr),
-          ret
-        );
-      }
-    });
-    return new Pair(Sym("let1"),
-             new Pair(tmp_sym,
-               new Pair(key,
-                 new Pair(ret, nil))));
+      });
+    return new Pair(
+      Sym("let1"),
+      new Pair(tmp_sym, new Pair(key, new Pair(ret, nil)))
+    );
   }
 });
 
-define_syntax("and", function(x){
+define_syntax("and", function (x) {
   // (and a b c) => (if a (if b c #f) #f)
   //todo: check improper list
-  if(x.cdr == nil) return true;
+  if (x.cdr == nil) return true;
 
   var objs = x.cdr.to_array();
-  var i = objs.length-1;
+  var i = objs.length - 1;
   var t = objs[i];
-  for(i=i-1; i>=0; i--)
-    t = List(Sym("if"), objs[i], t, false);
+  for (i = i - 1; i >= 0; i--) t = List(Sym("if"), objs[i], t, false);
 
   return t;
-})
+});
 
-define_syntax("or", function(x){
+define_syntax("or", function (x) {
   // (or a b c) => (if a a (if b b (if c c #f)))
   //todo: check improper list
 
-  var objs = x.cdr.to_array()
+  var objs = x.cdr.to_array();
   var f = false;
-  for(var i=objs.length-1; i>=0; i--)
+  for (var i = objs.length - 1; i >= 0; i--)
     f = List(Sym("if"), objs[i], objs[i], f);
 
   return f;
-})
+});
 
 //            11.4.6  Binding constructs
-define_syntax("let", function(x){
+define_syntax("let", function (x) {
   //(let ((a 1) (b 2)) (print a) (+ a b))
   //=> ((lambda (a b) (print a) (+ a b)) 1 2)
   var name = null;
@@ -195,16 +255,22 @@ define_syntax("let", function(x){
     name = x.cdr.car;
     x = x.cdr;
   }
-  var binds = x.cdr.car, body = x.cdr.cdr;
+  var binds = x.cdr.car,
+    body = x.cdr.cdr;
 
-  if((!(binds instanceof Pair)) && binds != nil){
-    throw new BiwaError("let: need a pair for bindings: got "+to_write(binds));
+  if (!(binds instanceof Pair) && binds != nil) {
+    throw new BiwaError(
+      "let: need a pair for bindings: got " + to_write(binds)
+    );
   }
 
-  var vars = nil, vals = nil;
-  for(var p=binds; p instanceof Pair; p=p.cdr){
-    if(!(p.car instanceof Pair)){
-      throw new BiwaError("let: need a pair for bindings: got "+to_write(p.car));
+  var vars = nil,
+    vals = nil;
+  for (var p = binds; p instanceof Pair; p = p.cdr) {
+    if (!(p.car instanceof Pair)) {
+      throw new BiwaError(
+        "let: need a pair for bindings: got " + to_write(p.car)
+      );
     }
     vars = new Pair(p.car.car, vars);
     vals = new Pair(p.car.cdr.car, vals);
@@ -220,64 +286,73 @@ define_syntax("let", function(x){
     var body_lambda = new Pair(Sym("lambda"), new Pair(vars, body));
     var init_call = new Pair(name, vals);
 
-    lambda = List(Sym("letrec"),
-                  new Pair(List(name, body_lambda), nil),
-                  init_call);
-  }
-  else {
-    lambda = new Pair(new Pair(Sym("lambda"),
-                               new Pair(vars, body)),
-                      vals);
+    lambda = List(
+      Sym("letrec"),
+      new Pair(List(name, body_lambda), nil),
+      init_call
+    );
+  } else {
+    lambda = new Pair(new Pair(Sym("lambda"), new Pair(vars, body)), vals);
   }
   return lambda;
-})
+});
 
-define_syntax("let*", function(x){
+define_syntax("let*", function (x) {
   //(let* ((a 1) (b a)) (print a) (+ a b))
   //-> (let ((a 1))
   //     (let ((b a)) (print a) (+ a b)))
-  var binds = x.cdr.car, body = x.cdr.cdr;
+  var binds = x.cdr.car,
+    body = x.cdr.cdr;
 
-  if(binds === nil)
-    return new Pair(Sym("let"), new Pair(nil, body));
+  if (binds === nil) return new Pair(Sym("let"), new Pair(nil, body));
 
-  if(!(binds instanceof Pair))
-    throw new BiwaError("let*: need a pair for bindings: got "+to_write(binds));
+  if (!(binds instanceof Pair))
+    throw new BiwaError(
+      "let*: need a pair for bindings: got " + to_write(binds)
+    );
 
   var ret = null;
-  _.each(binds.to_array().reverse(), function(bind){
-    ret = new Pair(Sym("let"),
-             new Pair(new Pair(bind, nil),
-               ret == null ? body : new Pair(ret, nil)));
-  })
+  binds
+    .to_array()
+    .reverse()
+    .forEach(function (bind) {
+      ret = new Pair(
+        Sym("let"),
+        new Pair(new Pair(bind, nil), ret == null ? body : new Pair(ret, nil))
+      );
+    });
   return ret;
-})
+});
 
-var expand_letrec_star = function(x){
-  var binds = x.cdr.car, body = x.cdr.cdr;
+var expand_letrec_star = function (x) {
+  var binds = x.cdr.car,
+    body = x.cdr.cdr;
 
-  if(!(binds instanceof Pair))
-    throw new BiwaError("letrec*: need a pair for bindings: got "+to_write(binds));
+  if (!(binds instanceof Pair))
+    throw new BiwaError(
+      "letrec*: need a pair for bindings: got " + to_write(binds)
+    );
 
   var ret = body;
-  _.each(binds.to_array().reverse(), function(bind){
-    ret = new Pair(new Pair(Sym("set!"), bind),
-            ret);
-  })
+  binds
+    .to_array()
+    .reverse()
+    .forEach(function (bind) {
+      ret = new Pair(new Pair(Sym("set!"), bind), ret);
+    });
   var letbody = nil;
-  _.each(binds.to_array().reverse(), function(bind){
-    letbody = new Pair(new Pair(bind.car,
-                         new Pair(undef, nil)),
-                letbody);
-  })
-  return new Pair(Sym("let"),
-           new Pair(letbody,
-             ret));
-}
+  binds
+    .to_array()
+    .reverse()
+    .forEach(function (bind) {
+      letbody = new Pair(new Pair(bind.car, new Pair(undef, nil)), letbody);
+    });
+  return new Pair(Sym("let"), new Pair(letbody, ret));
+};
 define_syntax("letrec", expand_letrec_star);
 define_syntax("letrec*", expand_letrec_star);
 
-define_syntax("let-values", function(x) {
+define_syntax("let-values", function (x) {
   // (let-values (((a b) (values 1 2))
   //               ((c d . e) (values 3 4 a)))
   //              (print a b c d e))
@@ -287,39 +362,47 @@ define_syntax("let-values", function(x) {
   //   (let*-values (((a b) #<gensym1>)
   //                 ((c d . e) #<gensym2>))
   //                 (print a b c d e)))
-    var mv_bindings = x.cdr.car;
-    var body = x.cdr.cdr;
-    var ret = null;
+  var mv_bindings = x.cdr.car;
+  var body = x.cdr.cdr;
+  var ret = null;
 
-    var let_bindings = nil;
-    var let_star_values_bindings = nil;
-    _.each(mv_bindings.to_array().reverse(), function (item) {
-  var init = item.cdr.car;
-  var tmpsym = gensym()
-  var binding = new Pair(tmpsym,
-       new Pair(
-          new Pair(Sym("lambda"), new Pair(nil,
-                   new Pair(init, nil))),
-          nil));
-  let_bindings = new Pair(binding, let_bindings);
+  var let_bindings = nil;
+  var let_star_values_bindings = nil;
+  mv_bindings
+    .to_array()
+    .reverse()
+    .forEach(function (item) {
+      var init = item.cdr.car;
+      var tmpsym = gensym();
+      var binding = new Pair(
+        tmpsym,
+        new Pair(
+          new Pair(Sym("lambda"), new Pair(nil, new Pair(init, nil))),
+          nil
+        )
+      );
+      let_bindings = new Pair(binding, let_bindings);
 
-  var formals = item.car;
-  let_star_values_bindings = new Pair(new Pair (formals, new Pair(new Pair(tmpsym, nil), nil)),
-              let_star_values_bindings);
+      var formals = item.car;
+      let_star_values_bindings = new Pair(
+        new Pair(formals, new Pair(new Pair(tmpsym, nil), nil)),
+        let_star_values_bindings
+      );
     });
 
-    var let_star_values = new Pair(Sym("let*-values"),
-           new Pair(let_star_values_bindings,
-              body));
-    ret = new Pair(Sym("let"),
-       new Pair(let_bindings,
-          new Pair (let_star_values, nil)));
-    return ret;
-
+  var let_star_values = new Pair(
+    Sym("let*-values"),
+    new Pair(let_star_values_bindings, body)
+  );
+  ret = new Pair(
+    Sym("let"),
+    new Pair(let_bindings, new Pair(let_star_values, nil))
+  );
+  return ret;
 });
 
 //let*-values
-define_syntax("let*-values", function(x){
+define_syntax("let*-values", function (x) {
   // (let*-values (((a b) (values 1 2))
   //               ((c d . e) (values 3 4 a)))
   //   (print a b c d e))
@@ -335,17 +418,26 @@ define_syntax("let*-values", function(x){
 
   var ret = null;
 
-  _.each(mv_bindings.to_array().reverse(), function(item){
-    var formals = item.car, init = item.cdr.car;
-    ret = new Pair(Sym("call-with-values"),
-            new Pair(new Pair(Sym("lambda"),
-                       new Pair(nil,
-                         new Pair(init, nil))),
-              new Pair(new Pair(Sym("lambda"),
-                         new Pair(formals,
-                           (ret == null ? body
-                                        : new Pair(ret, nil)))), nil)));
-  });
+  mv_bindings
+    .to_array()
+    .reverse()
+    .forEach(function (item) {
+      var formals = item.car,
+        init = item.cdr.car;
+      ret = new Pair(
+        Sym("call-with-values"),
+        new Pair(
+          new Pair(Sym("lambda"), new Pair(nil, new Pair(init, nil))),
+          new Pair(
+            new Pair(
+              Sym("lambda"),
+              new Pair(formals, ret == null ? body : new Pair(ret, nil))
+            ),
+            nil
+          )
+        )
+      );
+    });
   return ret;
 });
 //            11.4.7  Sequencing
@@ -354,23 +446,23 @@ define_syntax("let*-values", function(x){
 //
 //        11.5  Equivalence predicates
 //
-define_libfunc("eqv?", 2, 2, function(ar){
+define_libfunc("eqv?", 2, 2, function (ar) {
   return eqv(ar[0], ar[1]);
-})
-define_libfunc("eq?", 2, 2, function(ar){
+});
+define_libfunc("eq?", 2, 2, function (ar) {
   return eq(ar[0], ar[1]);
-})
-define_libfunc("equal?", 2, 2, function(ar){
+});
+define_libfunc("equal?", 2, 2, function (ar) {
   return equal(ar[0], ar[1]);
-})
+});
 
 //
 //        11.6  Procedure predicate
 //
 //"procedure?", 1, 1
-define_libfunc("procedure?", 1, 1, function(ar){
+define_libfunc("procedure?", 1, 1, function (ar) {
   return isProcedure(ar[0]);
-})
+});
 
 //
 //        11.7  Arithmetic
@@ -388,19 +480,19 @@ define_libfunc("procedure?", 1, 1, function(ar){
 //
 
 //                11.7.4.1  Numerical type predicates
-define_libfunc("number?", 1, 1, function(ar){
+define_libfunc("number?", 1, 1, function (ar) {
   return isNumber(ar[0]);
 });
-define_libfunc("complex?", 1, 1, function(ar){
+define_libfunc("complex?", 1, 1, function (ar) {
   return isComplex(ar[0]);
 });
-define_libfunc("real?", 1, 1, function(ar){
+define_libfunc("real?", 1, 1, function (ar) {
   return isReal(ar[0]);
 });
-define_libfunc("rational?", 1, 1, function(ar){
+define_libfunc("rational?", 1, 1, function (ar) {
   return isRational(ar[0]);
 });
-define_libfunc("integer?", 1, 1, function(ar){
+define_libfunc("integer?", 1, 1, function (ar) {
   return isInteger(ar[0]);
 });
 
@@ -419,568 +511,624 @@ define_libfunc("integer?", 1, 1, function(ar){
 //                11.7.4.3  Arithmetic operations
 
 //inf & nan: ok (for this section)
-define_libfunc("=", 2, null, function(ar){
+define_libfunc("=", 2, null, function (ar) {
   var v = ar[0];
   assert_number(ar[0]);
-  for(var i=1; i<ar.length; i++){
+  for (var i = 1; i < ar.length; i++) {
     assert_number(ar[i]);
-    if(real_part(ar[i]) != real_part(v)) return false;
-    if(imag_part(ar[i]) != imag_part(v)) return false;
+    if (real_part(ar[i]) != real_part(v)) return false;
+    if (imag_part(ar[i]) != imag_part(v)) return false;
   }
   return true;
 });
-define_libfunc("<", 2, null, function(ar){
+define_libfunc("<", 2, null, function (ar) {
   assert_number(ar[0]);
-  for(var i=1; i<ar.length; i++){
+  for (var i = 1; i < ar.length; i++) {
     assert_number(ar[i]);
-    if(!(ar[i-1] < ar[i])) return false;
+    if (!(ar[i - 1] < ar[i])) return false;
   }
   return true;
 });
-define_libfunc(">", 2, null, function(ar){
+define_libfunc(">", 2, null, function (ar) {
   assert_number(ar[0]);
-  for(var i=1; i<ar.length; i++){
+  for (var i = 1; i < ar.length; i++) {
     assert_number(ar[i]);
-    if(!(ar[i-1] > ar[i])) return false;
+    if (!(ar[i - 1] > ar[i])) return false;
   }
   return true;
 });
-define_libfunc("<=", 2, null, function(ar){
+define_libfunc("<=", 2, null, function (ar) {
   assert_number(ar[0]);
-  for(var i=1; i<ar.length; i++){
+  for (var i = 1; i < ar.length; i++) {
     assert_number(ar[i]);
-    if(!(ar[i-1] <= ar[i])) return false;
+    if (!(ar[i - 1] <= ar[i])) return false;
   }
   return true;
 });
-define_libfunc(">=", 2, null, function(ar){
+define_libfunc(">=", 2, null, function (ar) {
   assert_number(ar[0]);
-  for(var i=1; i<ar.length; i++){
+  for (var i = 1; i < ar.length; i++) {
     assert_number(ar[i]);
-    if(!(ar[i-1] >= ar[i])) return false;
+    if (!(ar[i - 1] >= ar[i])) return false;
   }
   return true;
 });
 
-define_libfunc("zero?", 1, 1, function(ar){
+define_libfunc("zero?", 1, 1, function (ar) {
   assert_number(ar[0]);
   return ar[0] === 0;
 });
-define_libfunc("positive?", 1, 1, function(ar){
+define_libfunc("positive?", 1, 1, function (ar) {
   assert_number(ar[0]);
-  return (ar[0] > 0);
+  return ar[0] > 0;
 });
-define_libfunc("negative?", 1, 1, function(ar){
+define_libfunc("negative?", 1, 1, function (ar) {
   assert_number(ar[0]);
-  return (ar[0] < 0);
+  return ar[0] < 0;
 });
-define_libfunc("odd?", 1, 1, function(ar){
+define_libfunc("odd?", 1, 1, function (ar) {
   assert_number(ar[0]);
-  return (ar[0] % 2 == 1) || (ar[0] % 2 == -1);
-})
-define_libfunc("even?", 1, 1, function(ar){
+  return ar[0] % 2 == 1 || ar[0] % 2 == -1;
+});
+define_libfunc("even?", 1, 1, function (ar) {
   assert_number(ar[0]);
   return ar[0] % 2 == 0;
-})
-define_libfunc("finite?", 1, 1, function(ar){
+});
+define_libfunc("finite?", 1, 1, function (ar) {
   assert_number(ar[0]);
-  return (ar[0] != Infinity) && (ar[0] != -Infinity) && !isNaN(ar[0]);
-})
-define_libfunc("infinite?", 1, 1, function(ar){
+  return ar[0] != Infinity && ar[0] != -Infinity && !isNaN(ar[0]);
+});
+define_libfunc("infinite?", 1, 1, function (ar) {
   assert_number(ar[0]);
-  return (ar[0] == Infinity) || (ar[0] == -Infinity);
-})
-define_libfunc("nan?", 1, 1, function(ar){
+  return ar[0] == Infinity || ar[0] == -Infinity;
+});
+define_libfunc("nan?", 1, 1, function (ar) {
   assert_number(ar[0]);
   return isNaN(ar[0]);
-})
-define_libfunc("max", 2, null, function(ar){
-  for(var i=0; i<ar.length; i++)
-    assert_number(ar[i]);
-
-  return Math.max.apply(null, ar)
 });
-define_libfunc("min", 2, null, function(ar){
-  for(var i=0; i<ar.length; i++)
-    assert_number(ar[i]);
+define_libfunc("max", 2, null, function (ar) {
+  for (var i = 0; i < ar.length; i++) assert_number(ar[i]);
+
+  return Math.max.apply(null, ar);
+});
+define_libfunc("min", 2, null, function (ar) {
+  for (var i = 0; i < ar.length; i++) assert_number(ar[i]);
 
   return Math.min.apply(null, ar);
 });
 
-var complex_or_real = function(real,imag){
-  if(imag === 0) return real;
-  return new Complex(real,imag);
-}
-var polar_or_real = function(magnitude, angle){
-    if(angle === 0) return magnitude;
-    return Complex.from_polar(magnitude, angle);
-}
-define_libfunc("+", 0,null, function(ar){
+var complex_or_real = function (real, imag) {
+  if (imag === 0) return real;
+  return new Complex(real, imag);
+};
+var polar_or_real = function (magnitude, angle) {
+  if (angle === 0) return magnitude;
+  return Complex.from_polar(magnitude, angle);
+};
+define_libfunc("+", 0, null, function (ar) {
   var real = 0;
   var imag = 0;
-  for(var i=0; i<ar.length; i++){
+  for (var i = 0; i < ar.length; i++) {
     assert_number(ar[i]);
-    real+=real_part(ar[i]);
-    imag+=imag_part(ar[i]);
+    real += real_part(ar[i]);
+    imag += imag_part(ar[i]);
   }
-  return complex_or_real(real,imag);
+  return complex_or_real(real, imag);
 });
-var the_magnitude = function(n) {
-    if(n instanceof Complex) return n.magnitude();
-    return n;
-}
-var the_angle = function(n) {
-    if(n instanceof Complex) return n.angle();
-    return 0;
-}
-define_libfunc("*", 0,null, function(ar){
+var the_magnitude = function (n) {
+  if (n instanceof Complex) return n.magnitude();
+  return n;
+};
+var the_angle = function (n) {
+  if (n instanceof Complex) return n.angle();
+  return 0;
+};
+define_libfunc("*", 0, null, function (ar) {
   var magnitude = 1;
   var angle = 0;
-  for(var i=0; i<ar.length; i++){
+  for (var i = 0; i < ar.length; i++) {
     assert_number(ar[i]);
-    magnitude*=the_magnitude(ar[i]);
-    angle+=the_angle(ar[i]);
+    magnitude *= the_magnitude(ar[i]);
+    angle += the_angle(ar[i]);
   }
   return polar_or_real(magnitude, angle);
 });
-define_libfunc("-", 1,null, function(ar){
+define_libfunc("-", 1, null, function (ar) {
   var len = ar.length;
   assert_number(ar[0]);
 
-  if(len == 1) {
-    if(ar[0] instanceof Complex) return new Complex(-real_part(ar[0]),-imag_part(ar[0]));
+  if (len == 1) {
+    if (ar[0] instanceof Complex)
+      return new Complex(-real_part(ar[0]), -imag_part(ar[0]));
     return -ar[0];
-  }
-  else{
+  } else {
     var real = real_part(ar[0]);
     var imag = imag_part(ar[0]);
-    for(var i=1; i<len; i++){
+    for (var i = 1; i < len; i++) {
       assert_number(ar[i]);
-      real-=real_part(ar[i]);
-      imag-=imag_part(ar[i]);
+      real -= real_part(ar[i]);
+      imag -= imag_part(ar[i]);
     }
-    return complex_or_real(real,imag);
+    return complex_or_real(real, imag);
   }
 });
 //for r6rs specification, (/ 0 0) or (/ 3 0) raises '&assertion exception'
-define_libfunc("/", 1,null, function(ar){
+define_libfunc("/", 1, null, function (ar) {
   var len = ar.length;
   assert_number(ar[0]);
 
-  if(len == 1){
-    if (ar[0] instanceof Complex) return Complex.from_polar(1/the_magnitude(ar[0]), -the_angle(ar[0]));
-    return 1/ar[0];
-  }
-  else{
+  if (len == 1) {
+    if (ar[0] instanceof Complex)
+      return Complex.from_polar(1 / the_magnitude(ar[0]), -the_angle(ar[0]));
+    return 1 / ar[0];
+  } else {
     var magnitude = the_magnitude(ar[0]);
     var angle = the_angle(ar[0]);
-    for(var i=1; i<len; i++){
+    for (var i = 1; i < len; i++) {
       assert_number(ar[i]);
-      magnitude/=the_magnitude(ar[i]);
-      angle-=the_angle(ar[i]);
+      magnitude /= the_magnitude(ar[i]);
+      angle -= the_angle(ar[i]);
     }
     return polar_or_real(magnitude, angle);
   }
 });
 
-define_libfunc("abs", 1, 1, function(ar){
+define_libfunc("abs", 1, 1, function (ar) {
   assert_number(ar[0]);
   return Math.abs(ar[0]);
 });
 
-var div = function(n, m){
+var div = function (n, m) {
   return Math.floor(n / m);
-}
-var mod = function(n, m){
+};
+var mod = function (n, m) {
   return n - Math.floor(n / m) * m;
-}
-var div0 = function(n, m){
-  return (n > 0) ? Math.floor(n / m) : Math.ceil(n / m);
-}
-var mod0 = function(n, m){
-  return (n > 0) ? n - Math.floor(n / m) * m
-                 : n - Math.ceil(n / m) * m;
-}
-define_libfunc("div0-and-mod0", 2, 2, function(ar){
+};
+var div0 = function (n, m) {
+  return n > 0 ? Math.floor(n / m) : Math.ceil(n / m);
+};
+var mod0 = function (n, m) {
+  return n > 0 ? n - Math.floor(n / m) * m : n - Math.ceil(n / m) * m;
+};
+define_libfunc("div0-and-mod0", 2, 2, function (ar) {
   assert_number(ar[0]);
   assert_number(ar[1]);
   return new Values([div(ar[0], ar[1]), mod(ar[0], ar[1])]);
-})
-define_libfunc("div", 2, 2, function(ar){
+});
+define_libfunc("div", 2, 2, function (ar) {
   assert_number(ar[0]);
   assert_number(ar[1]);
   return div(ar[0], ar[1]);
-})
-define_libfunc("mod", 2, 2, function(ar){
+});
+define_libfunc("mod", 2, 2, function (ar) {
   assert_number(ar[0]);
   assert_number(ar[1]);
   return mod(ar[0], ar[1]);
-})
-define_libfunc("div0-and-mod0", 2, 2, function(ar){
+});
+define_libfunc("div0-and-mod0", 2, 2, function (ar) {
   assert_number(ar[0]);
   assert_number(ar[1]);
   return new Values([div0(ar[0], ar[1]), mod0(ar[0], ar[1])]);
-})
-define_libfunc("div0", 2, 2, function(ar){
+});
+define_libfunc("div0", 2, 2, function (ar) {
   assert_number(ar[0]);
   assert_number(ar[1]);
   return div0(ar[0], ar[1]);
-})
-define_libfunc("mod0", 2, 2, function(ar){
+});
+define_libfunc("mod0", 2, 2, function (ar) {
   assert_number(ar[0]);
   assert_number(ar[1]);
   return mod0(ar[0], ar[1]);
-})
+});
 
 //(gcd n1 ...)    procedure
 //(lcm n1 ...)    procedure
 
-define_libfunc("numerator", 1, 1, function(ar){
+define_libfunc("numerator", 1, 1, function (ar) {
   assert_number(ar[0]);
-  if(ar[0] instanceof Rational)
-    return ar[0].numerator;
-  else
-    throw new Bug("todo");
-})
-define_libfunc("denominator", 1, 1, function(ar){
+  if (ar[0] instanceof Rational) return ar[0].numerator;
+  else throw new Bug("todo");
+});
+define_libfunc("denominator", 1, 1, function (ar) {
   assert_number(ar[0]);
-  if(ar[0] instanceof Rational)
-    return ar[0].denominator;
-  else
-    throw new Bug("todo");
-})
-define_libfunc("floor", 1, 1, function(ar){
+  if (ar[0] instanceof Rational) return ar[0].denominator;
+  else throw new Bug("todo");
+});
+define_libfunc("floor", 1, 1, function (ar) {
   assert_number(ar[0]);
   return Math.floor(ar[0]);
-})
-define_libfunc("ceiling", 1, 1, function(ar){
+});
+define_libfunc("ceiling", 1, 1, function (ar) {
   assert_number(ar[0]);
   return Math.ceil(ar[0]);
-})
-define_libfunc("truncate", 1, 1, function(ar){
+});
+define_libfunc("truncate", 1, 1, function (ar) {
   assert_number(ar[0]);
-  return (ar[0] < 0) ? Math.ceil(ar[0]) : Math.floor(ar[0]);
-})
-define_libfunc("round", 1, 1, function(ar){
+  return ar[0] < 0 ? Math.ceil(ar[0]) : Math.floor(ar[0]);
+});
+define_libfunc("round", 1, 1, function (ar) {
   assert_number(ar[0]);
   return Math.round(ar[0]);
-})
+});
 
 //(rationalize x1 x2)    procedure
 
-define_libfunc("exp", 1, 1, function(ar){
+define_libfunc("exp", 1, 1, function (ar) {
   assert_number(ar[0]);
   return Math.exp(ar[0]);
-})
-define_libfunc("log", 1, 2, function(ar){
-  var num = ar[0], base = ar[1];
+});
+define_libfunc("log", 1, 2, function (ar) {
+  var num = ar[0],
+    base = ar[1];
   assert_number(num);
 
-  if(base){ // log b num == log e num / log e b
+  if (base) {
+    // log b num == log e num / log e b
     assert_number(base);
-    return Math.log(num) / Math.log(base)
-  }
-  else
-    return Math.log(num);
-})
-define_libfunc("sin", 1, 1, function(ar){
+    return Math.log(num) / Math.log(base);
+  } else return Math.log(num);
+});
+define_libfunc("sin", 1, 1, function (ar) {
   assert_number(ar[0]);
   return Math.sin(ar[0]);
-})
-define_libfunc("cos", 1, 1, function(ar){
+});
+define_libfunc("cos", 1, 1, function (ar) {
   assert_number(ar[0]);
   return Math.cos(ar[0]);
-})
-define_libfunc("tan", 1, 1, function(ar){
+});
+define_libfunc("tan", 1, 1, function (ar) {
   assert_number(ar[0]);
   return Math.tan(ar[0]);
-})
-define_libfunc("asin", 1, 1, function(ar){
+});
+define_libfunc("asin", 1, 1, function (ar) {
   assert_number(ar[0]);
   return Math.asin(ar[0]);
-})
-define_libfunc("acos", 1, 1, function(ar){
+});
+define_libfunc("acos", 1, 1, function (ar) {
   assert_number(ar[0]);
   return Math.acos(ar[0]);
-})
-define_libfunc("atan", 1, 2, function(ar){
+});
+define_libfunc("atan", 1, 2, function (ar) {
   assert_number(ar[0]);
-  if(ar.length == 2){
+  if (ar.length == 2) {
     assert_number(ar[1]);
     return Math.atan2(ar[0], ar[1]);
-  }
-  else
-    return Math.atan(ar[0]);
-})
-define_libfunc("sqrt", 1, 1, function(ar){
+  } else return Math.atan(ar[0]);
+});
+define_libfunc("sqrt", 1, 1, function (ar) {
   assert_number(ar[0]);
   return Math.sqrt(ar[0]);
-})
-define_libfunc("exact-integer-sqrt", 1, 1, function(ar){
+});
+define_libfunc("exact-integer-sqrt", 1, 1, function (ar) {
   assert_number(ar[0]);
   var sqrt_f = Math.sqrt(ar[0]);
   var sqrt_i = sqrt_f - (sqrt_f % 1);
-  var rest   = ar[0] - sqrt_i * sqrt_i;
+  var rest = ar[0] - sqrt_i * sqrt_i;
 
   return new Values([sqrt_i, rest]);
-})
-define_libfunc("expt", 2, 2, function(ar){
+});
+define_libfunc("expt", 2, 2, function (ar) {
   assert_number(ar[0]);
   assert_number(ar[1]);
   return Math.pow(ar[0], ar[1]);
-})
-define_libfunc("make-rectangular", 2, 2, function(ar){
+});
+define_libfunc("make-rectangular", 2, 2, function (ar) {
   assert_number(ar[0]);
   assert_number(ar[1]);
   return new Complex(ar[0], ar[1]);
-})
-define_libfunc("make-polar", 2, 2, function(ar){
+});
+define_libfunc("make-polar", 2, 2, function (ar) {
   assert_number(ar[0]);
   assert_number(ar[1]);
   return Complex.from_polar(ar[0], ar[1]);
-})
-var real_part = function(n) {
+});
+var real_part = function (n) {
   return Complex.assure(n).real;
-}
-var imag_part = function(n) {
+};
+var imag_part = function (n) {
   return Complex.assure(n).imag;
-}
-define_libfunc("real-part", 1, 1, function(ar){
+};
+define_libfunc("real-part", 1, 1, function (ar) {
   assert_number(ar[0]);
   return real_part(ar[0]);
-})
-define_libfunc("imag-part", 1, 1, function(ar){
+});
+define_libfunc("imag-part", 1, 1, function (ar) {
   assert_number(ar[0]);
   return Complex.assure(ar[0]).imag;
-})
-define_libfunc("magnitude", 1, 1, function(ar){
+});
+define_libfunc("magnitude", 1, 1, function (ar) {
   assert_number(ar[0]);
   return Complex.assure(ar[0]).magnitude();
-})
-define_libfunc("angle", 1, 1, function(ar){
+});
+define_libfunc("angle", 1, 1, function (ar) {
   assert_number(ar[0]);
   return Complex.assure(ar[0]).angle();
-})
+});
 
 //
 //                11.7.4.4  Numerical Input and Output
 //
-define_libfunc("number->string", 1, 3, function(ar){
-  var z = ar[0], radix = ar[1], precision = ar[2];
-  if(precision)
+define_libfunc("number->string", 1, 3, function (ar) {
+  var z = ar[0],
+    radix = ar[1],
+    precision = ar[2];
+  if (precision)
     throw new Bug("number->string: precision is not yet implemented");
 
-  radix = radix || 10;  //TODO: check radix is 2, 8, 10, or 16.
+  radix = radix || 10; //TODO: check radix is 2, 8, 10, or 16.
   return z.toString(radix);
-})
-define_libfunc("string->number", 1, 3, function(ar){
+});
+define_libfunc("string->number", 1, 3, function (ar) {
   var s = ar[0];
 
-  if (s === '+inf.0')
-    return Infinity;
+  if (s === "+inf.0") return Infinity;
 
-  if (s === '-inf.0')
-    return -Infinity;
+  if (s === "-inf.0") return -Infinity;
 
-  if (s === '+nan.0')
-    return NaN;
+  if (s === "+nan.0") return NaN;
 
   var radix = ar[1];
-  
-  var int_res = parse_integer(
-    s, radix === 0 ? 0 : radix || 10
-  );
 
-  if (int_res !== false)
-    return int_res;
+  var int_res = parse_integer(s, radix === 0 ? 0 : radix || 10);
 
-  if (radix !== undefined && radix !== 10)
-    return false;
+  if (int_res !== false) return int_res;
+
+  if (radix !== undefined && radix !== 10) return false;
 
   var fp_res = parse_float(s);
 
-  if (fp_res !== false)
-    return fp_res;
+  if (fp_res !== false) return fp_res;
 
   var frac_res = parse_fraction(s);
 
-  if (frac_res !== false)
-    return frac_res;
+  if (frac_res !== false) return frac_res;
 
   return false;
-})
+});
 
 //
 //        11.8  Booleans
 //
 
-define_libfunc("not", 1, 1, function(ar){
-  return (ar[0] === false) ? true : false;
+define_libfunc("not", 1, 1, function (ar) {
+  return ar[0] === false ? true : false;
 });
-define_libfunc("boolean?", 1, 1, function(ar){
-  return (ar[0] === false || ar[0] === true) ? true : false;
+define_libfunc("boolean?", 1, 1, function (ar) {
+  return ar[0] === false || ar[0] === true ? true : false;
 });
-define_libfunc("boolean=?", 2, null, function(ar){
+define_libfunc("boolean=?", 2, null, function (ar) {
   var len = ar.length;
-  for(var i=1; i<len; i++){
-    if(ar[i] != ar[0]) return false;
+  for (var i = 1; i < len; i++) {
+    if (ar[i] != ar[0]) return false;
   }
   return true;
 });
 
 //        11.9  Pairs and lists
 
-define_libfunc("pair?", 1, 1, function(ar){
-  return (ar[0] instanceof Pair) ? true : false;
+define_libfunc("pair?", 1, 1, function (ar) {
+  return ar[0] instanceof Pair ? true : false;
 });
-define_libfunc("cons", 2, 2, function(ar){
+define_libfunc("cons", 2, 2, function (ar) {
   return new Pair(ar[0], ar[1]);
 });
-define_libfunc("car", 1, 1, function(ar){
+define_libfunc("car", 1, 1, function (ar) {
   //should raise &assertion for '()...
-  if(!(ar[0] instanceof Pair)) throw new BiwaError("Attempt to apply car on " + ar[0]);
+  if (!(ar[0] instanceof Pair))
+    throw new BiwaError("Attempt to apply car on " + ar[0]);
   return ar[0].car;
 });
-define_libfunc("cdr", 1, 1, function(ar){
+define_libfunc("cdr", 1, 1, function (ar) {
   //should raise &assertion for '()...
-  if(!(ar[0] instanceof Pair)) throw new BiwaError("Attempt to apply cdr on " + ar[0]);
+  if (!(ar[0] instanceof Pair))
+    throw new BiwaError("Attempt to apply cdr on " + ar[0]);
   return ar[0].cdr;
 });
-define_libfunc("set-car!", 2, 2, function(ar){
-  if(!(ar[0] instanceof Pair)) throw new BiwaError("Attempt to apply set-car! on " + ar[0]);
+define_libfunc("set-car!", 2, 2, function (ar) {
+  if (!(ar[0] instanceof Pair))
+    throw new BiwaError("Attempt to apply set-car! on " + ar[0]);
   ar[0].car = ar[1];
   return undef;
 });
-define_libfunc("set-cdr!", 2, 2, function(ar){
-  if(!(ar[0] instanceof Pair)) throw new BiwaError("Attempt to apply set-cdr! on " + ar[0]);
+define_libfunc("set-cdr!", 2, 2, function (ar) {
+  if (!(ar[0] instanceof Pair))
+    throw new BiwaError("Attempt to apply set-cdr! on " + ar[0]);
   ar[0].cdr = ar[1];
   return undef;
 });
 
 // cadr, caddr, cadddr, etc.
-(function(){
+(function () {
   // To traverse into pair and raise error
-  var get = function(funcname, spec, obj){
+  var get = function (funcname, spec, obj) {
     var ret = obj;
-    _.each(spec, function(is_cdr){
-      if(ret instanceof Pair){
-        ret = (is_cdr ? ret.cdr : ret.car);
-      }
-      else{
-        throw new BiwaError(funcname+": attempt to get "+(is_cdr ? "cdr" : "car")+" of "+ret);
+    spec.forEach(function (is_cdr) {
+      if (ret instanceof Pair) {
+        ret = is_cdr ? ret.cdr : ret.car;
+      } else {
+        throw new BiwaError(
+          funcname +
+            ": attempt to get " +
+            (is_cdr ? "cdr" : "car") +
+            " of " +
+            ret
+        );
       }
     });
     return ret;
   };
-  define_libfunc("caar", 1, 1, function(ar){ return get("caar", [0, 0], ar[0]); });
-  define_libfunc("cadr", 1, 1, function(ar){ return get("cadr", [1, 0], ar[0]); });
-  define_libfunc("cdar", 1, 1, function(ar){ return get("cadr", [0, 1], ar[0]); });
-  define_libfunc("cddr", 1, 1, function(ar){ return get("cadr", [1, 1], ar[0]); });
+  define_libfunc("caar", 1, 1, function (ar) {
+    return get("caar", [0, 0], ar[0]);
+  });
+  define_libfunc("cadr", 1, 1, function (ar) {
+    return get("cadr", [1, 0], ar[0]);
+  });
+  define_libfunc("cdar", 1, 1, function (ar) {
+    return get("cadr", [0, 1], ar[0]);
+  });
+  define_libfunc("cddr", 1, 1, function (ar) {
+    return get("cadr", [1, 1], ar[0]);
+  });
 
-  define_libfunc("caaar", 1, 1, function(ar){ return get("caaar", [0, 0, 0], ar[0]); });
-  define_libfunc("caadr", 1, 1, function(ar){ return get("caadr", [1, 0, 0], ar[0]); });
-  define_libfunc("cadar", 1, 1, function(ar){ return get("cadar", [0, 1, 0], ar[0]); });
-  define_libfunc("caddr", 1, 1, function(ar){ return get("caddr", [1, 1, 0], ar[0]); });
-  define_libfunc("cdaar", 1, 1, function(ar){ return get("cdaar", [0, 0, 1], ar[0]); });
-  define_libfunc("cdadr", 1, 1, function(ar){ return get("cdadr", [1, 0, 1], ar[0]); });
-  define_libfunc("cddar", 1, 1, function(ar){ return get("cddar", [0, 1, 1], ar[0]); });
-  define_libfunc("cdddr", 1, 1, function(ar){ return get("cdddr", [1, 1, 1], ar[0]); });
+  define_libfunc("caaar", 1, 1, function (ar) {
+    return get("caaar", [0, 0, 0], ar[0]);
+  });
+  define_libfunc("caadr", 1, 1, function (ar) {
+    return get("caadr", [1, 0, 0], ar[0]);
+  });
+  define_libfunc("cadar", 1, 1, function (ar) {
+    return get("cadar", [0, 1, 0], ar[0]);
+  });
+  define_libfunc("caddr", 1, 1, function (ar) {
+    return get("caddr", [1, 1, 0], ar[0]);
+  });
+  define_libfunc("cdaar", 1, 1, function (ar) {
+    return get("cdaar", [0, 0, 1], ar[0]);
+  });
+  define_libfunc("cdadr", 1, 1, function (ar) {
+    return get("cdadr", [1, 0, 1], ar[0]);
+  });
+  define_libfunc("cddar", 1, 1, function (ar) {
+    return get("cddar", [0, 1, 1], ar[0]);
+  });
+  define_libfunc("cdddr", 1, 1, function (ar) {
+    return get("cdddr", [1, 1, 1], ar[0]);
+  });
 
-  define_libfunc("caaaar", 1, 1, function(ar){ return get("caaaar", [0, 0, 0, 0], ar[0]); });
-  define_libfunc("caaadr", 1, 1, function(ar){ return get("caaadr", [1, 0, 0, 0], ar[0]); });
-  define_libfunc("caadar", 1, 1, function(ar){ return get("caadar", [0, 1, 0, 0], ar[0]); });
-  define_libfunc("caaddr", 1, 1, function(ar){ return get("caaddr", [1, 1, 0, 0], ar[0]); });
-  define_libfunc("cadaar", 1, 1, function(ar){ return get("cadaar", [0, 0, 1, 0], ar[0]); });
-  define_libfunc("cadadr", 1, 1, function(ar){ return get("cadadr", [1, 0, 1, 0], ar[0]); });
-  define_libfunc("caddar", 1, 1, function(ar){ return get("caddar", [0, 1, 1, 0], ar[0]); });
-  define_libfunc("cadddr", 1, 1, function(ar){ return get("cadddr", [1, 1, 1, 0], ar[0]); });
-  define_libfunc("cdaaar", 1, 1, function(ar){ return get("cdaaar", [0, 0, 0, 1], ar[0]); });
-  define_libfunc("cdaadr", 1, 1, function(ar){ return get("cdaadr", [1, 0, 0, 1], ar[0]); });
-  define_libfunc("cdadar", 1, 1, function(ar){ return get("cdadar", [0, 1, 0, 1], ar[0]); });
-  define_libfunc("cdaddr", 1, 1, function(ar){ return get("cdaddr", [1, 1, 0, 1], ar[0]); });
-  define_libfunc("cddaar", 1, 1, function(ar){ return get("cddaar", [0, 0, 1, 1], ar[0]); });
-  define_libfunc("cddadr", 1, 1, function(ar){ return get("cddadr", [1, 0, 1, 1], ar[0]); });
-  define_libfunc("cdddar", 1, 1, function(ar){ return get("cdddar", [0, 1, 1, 1], ar[0]); });
-  define_libfunc("cddddr", 1, 1, function(ar){ return get("cddddr", [1, 1, 1, 1], ar[0]); });
+  define_libfunc("caaaar", 1, 1, function (ar) {
+    return get("caaaar", [0, 0, 0, 0], ar[0]);
+  });
+  define_libfunc("caaadr", 1, 1, function (ar) {
+    return get("caaadr", [1, 0, 0, 0], ar[0]);
+  });
+  define_libfunc("caadar", 1, 1, function (ar) {
+    return get("caadar", [0, 1, 0, 0], ar[0]);
+  });
+  define_libfunc("caaddr", 1, 1, function (ar) {
+    return get("caaddr", [1, 1, 0, 0], ar[0]);
+  });
+  define_libfunc("cadaar", 1, 1, function (ar) {
+    return get("cadaar", [0, 0, 1, 0], ar[0]);
+  });
+  define_libfunc("cadadr", 1, 1, function (ar) {
+    return get("cadadr", [1, 0, 1, 0], ar[0]);
+  });
+  define_libfunc("caddar", 1, 1, function (ar) {
+    return get("caddar", [0, 1, 1, 0], ar[0]);
+  });
+  define_libfunc("cadddr", 1, 1, function (ar) {
+    return get("cadddr", [1, 1, 1, 0], ar[0]);
+  });
+  define_libfunc("cdaaar", 1, 1, function (ar) {
+    return get("cdaaar", [0, 0, 0, 1], ar[0]);
+  });
+  define_libfunc("cdaadr", 1, 1, function (ar) {
+    return get("cdaadr", [1, 0, 0, 1], ar[0]);
+  });
+  define_libfunc("cdadar", 1, 1, function (ar) {
+    return get("cdadar", [0, 1, 0, 1], ar[0]);
+  });
+  define_libfunc("cdaddr", 1, 1, function (ar) {
+    return get("cdaddr", [1, 1, 0, 1], ar[0]);
+  });
+  define_libfunc("cddaar", 1, 1, function (ar) {
+    return get("cddaar", [0, 0, 1, 1], ar[0]);
+  });
+  define_libfunc("cddadr", 1, 1, function (ar) {
+    return get("cddadr", [1, 0, 1, 1], ar[0]);
+  });
+  define_libfunc("cdddar", 1, 1, function (ar) {
+    return get("cdddar", [0, 1, 1, 1], ar[0]);
+  });
+  define_libfunc("cddddr", 1, 1, function (ar) {
+    return get("cddddr", [1, 1, 1, 1], ar[0]);
+  });
 })();
 
-define_libfunc("null?", 1, 1, function(ar){
-  return (ar[0] === nil);
+define_libfunc("null?", 1, 1, function (ar) {
+  return ar[0] === nil;
 });
-define_libfunc("list?", 1, 1, function(ar){
+define_libfunc("list?", 1, 1, function (ar) {
   return isList(ar[0]);
 });
-define_libfunc("list", 0, null, function(ar){
+define_libfunc("list", 0, null, function (ar) {
   var l = nil;
-  for(var i=ar.length-1; i>=0; i--)
-    l = new Pair(ar[i], l);
+  for (var i = ar.length - 1; i >= 0; i--) l = new Pair(ar[i], l);
   return l;
 });
-define_libfunc("length", 1, 1, function(ar){
+define_libfunc("length", 1, 1, function (ar) {
   assert_list(ar[0]);
   var n = 0;
-  for(var o=ar[0]; o!=nil; o=o.cdr)
-    n++;
+  for (var o = ar[0]; o != nil; o = o.cdr) n++;
   return n;
 });
-define_libfunc("append", 1, null, function(ar){
+define_libfunc("append", 1, null, function (ar) {
   var k = ar.length;
   var ret = ar[--k];
-  while(k--){
-    _.each(ar[k].to_array().reverse(), function(item){
-      ret = new Pair(item, ret);
-    });
+  while (k--) {
+    ar[k]
+      .to_array()
+      .reverse()
+      .forEach(function (item) {
+        ret = new Pair(item, ret);
+      });
   }
   return ret;
 });
-define_libfunc("reverse", 1, 1, function(ar){
+define_libfunc("reverse", 1, 1, function (ar) {
   // (reverse '()) => '()
-  if(ar[0] == nil)
-    return nil;
+  if (ar[0] == nil) return nil;
   assert_pair(ar[0]);
 
   var l = nil;
-  for(var o=ar[0]; o!=nil; o=o.cdr)
-    l = new Pair(o.car, l);
+  for (var o = ar[0]; o != nil; o = o.cdr) l = new Pair(o.car, l);
   return l;
 });
-define_libfunc("list-tail", 2, 2, function(ar){
+define_libfunc("list-tail", 2, 2, function (ar) {
   assert_pair(ar[0]);
   assert_integer(ar[1]);
-  if(ar[1] < 0)
-    throw new BiwaError("list-tail: index out of range ("+ar[1]+")");
+  if (ar[1] < 0)
+    throw new BiwaError("list-tail: index out of range (" + ar[1] + ")");
 
   var o = ar[0];
-  for(var i=0; i<ar[1]; i++){
-    if(!(o instanceof Pair)) throw new BiwaError("list-tail: the list is shorter than " + ar[1]);
+  for (var i = 0; i < ar[1]; i++) {
+    if (!(o instanceof Pair))
+      throw new BiwaError("list-tail: the list is shorter than " + ar[1]);
     o = o.cdr;
   }
   return o;
 });
-define_libfunc("list-ref", 2, 2, function(ar){
+define_libfunc("list-ref", 2, 2, function (ar) {
   assert_pair(ar[0]);
   assert_integer(ar[1]);
-  if(ar[1] < 0)
-    throw new BiwaError("list-tail: index out of range ("+ar[1]+")");
+  if (ar[1] < 0)
+    throw new BiwaError("list-tail: index out of range (" + ar[1] + ")");
 
   var o = ar[0];
-  for(var i=0; i<ar[1]; i++){
-    if(!(o instanceof Pair)) throw new BiwaError("list-ref: the list is shorter than " + ar[1]);
+  for (var i = 0; i < ar[1]; i++) {
+    if (!(o instanceof Pair))
+      throw new BiwaError("list-ref: the list is shorter than " + ar[1]);
     o = o.cdr;
   }
   return o.car;
 });
-define_libfunc("map", 2, null, function(ar){
-  var proc = ar.shift(), lists = ar;
-  _.each(lists, assert_list);
+define_libfunc("map", 2, null, function (ar) {
+  var proc = ar.shift(),
+    lists = ar;
+  lists.forEach(assert_list);
 
   var a = [];
   return Call.multi_foreach(lists, {
     // Called for each element
     // input: the element (or the elements, if more than one list is given)
     // output: a Call request of proc and args
-    call: function(xs){
-      return new Call(proc, _.map(xs, function(x){ return x.car }));
+    call: function (xs) {
+      return new Call(
+        proc,
+        _.map(xs, function (x) {
+          return x.car;
+        })
+      );
     },
 
     // Called when each Call request is finished
@@ -988,44 +1136,56 @@ define_libfunc("map", 2, null, function(ar){
     //   the element(s) of the Call request (which is not used here)
     // output: `undefined' to continue,
     //   some value to terminate (the value will be the result)
-    result: function(res){ a.push(res); },
+    result: function (res) {
+      a.push(res);
+    },
 
     // Called when reached to the end of the list(s)
     // input: none
     // output: the resultant value
-    finish: function(){ return array_to_list(a); }
-  })
-})
-define_libfunc("for-each", 2, null, function(ar){
-  var proc = ar.shift(), lists = ar;
-  _.each(lists, assert_list);
+    finish: function () {
+      return array_to_list(a);
+    },
+  });
+});
+define_libfunc("for-each", 2, null, function (ar) {
+  var proc = ar.shift(),
+    lists = ar;
+  lists.forEach(assert_list);
 
   return Call.multi_foreach(lists, {
-    call: function(xs){
-      return new Call(proc, _.map(xs, function(x){ return x.car }));
+    call: function (xs) {
+      return new Call(
+        proc,
+        _.map(xs, function (x) {
+          return x.car;
+        })
+      );
     },
-    finish: function(){ return undef; }
-  })
-})
+    finish: function () {
+      return undef;
+    },
+  });
+});
 
 //        11.10  Symbols
 
-define_libfunc("symbol?", 1, 1, function(ar){
-  return (ar[0] instanceof BiwaSymbol) ? true : false;
+define_libfunc("symbol?", 1, 1, function (ar) {
+  return ar[0] instanceof BiwaSymbol ? true : false;
 });
-define_libfunc("symbol->string", 1, 1, function(ar){
+define_libfunc("symbol->string", 1, 1, function (ar) {
   assert_symbol(ar[0]);
   return ar[0].name;
 });
-define_libfunc("symbol=?", 2, null, function(ar){
+define_libfunc("symbol=?", 2, null, function (ar) {
   assert_symbol(ar[0]);
-  for(var i=1; i<ar.length; i++){
+  for (var i = 1; i < ar.length; i++) {
     assert_symbol(ar[i]);
-    if(ar[i] != ar[0]) return false;
+    if (ar[i] != ar[0]) return false;
   }
   return true;
 });
-define_libfunc("string->symbol", 1, 1, function(ar){
+define_libfunc("string->symbol", 1, 1, function (ar) {
   assert_string(ar[0]);
   return Sym(ar[0]);
 });
@@ -1033,230 +1193,285 @@ define_libfunc("string->symbol", 1, 1, function(ar){
 //
 //        11.11  Characters
 //
-define_libfunc('char?', 1, 1, function(ar){
-  return (ar[0] instanceof Char);
+define_libfunc("char?", 1, 1, function (ar) {
+  return ar[0] instanceof Char;
 });
-define_libfunc('char->integer', 1, 1, function(ar){
+define_libfunc("char->integer", 1, 1, function (ar) {
   assert_char(ar[0]);
   return ar[0].value.charCodeAt(0);
-})
-define_libfunc('integer->char', 1, 1, function(ar){
+});
+define_libfunc("integer->char", 1, 1, function (ar) {
   assert_integer(ar[0]);
   return Char.get(String.fromCharCode(ar[0]));
-})
+});
 
-var make_char_compare_func = function(test){
-  return function(ar){
+var make_char_compare_func = function (test) {
+  return function (ar) {
     assert_char(ar[0]);
-    for(var i=1; i<ar.length; i++){
+    for (var i = 1; i < ar.length; i++) {
       assert_char(ar[i]);
-      if(!test(ar[i-1].value, ar[i].value))
-        return false;
+      if (!test(ar[i - 1].value, ar[i].value)) return false;
     }
     return true;
-  }
-}
-define_libfunc('char=?', 2, null,
-  make_char_compare_func(function(a, b){ return a == b }))
-define_libfunc('char<?', 2, null,
-  make_char_compare_func(function(a, b){ return a < b }))
-define_libfunc('char>?', 2, null,
-  make_char_compare_func(function(a, b){ return a > b }))
-define_libfunc('char<=?', 2, null,
-  make_char_compare_func(function(a, b){ return a <= b }))
-define_libfunc('char>=?', 2, null,
-  make_char_compare_func(function(a, b){ return a >= b }))
+  };
+};
+define_libfunc(
+  "char=?",
+  2,
+  null,
+  make_char_compare_func(function (a, b) {
+    return a == b;
+  })
+);
+define_libfunc(
+  "char<?",
+  2,
+  null,
+  make_char_compare_func(function (a, b) {
+    return a < b;
+  })
+);
+define_libfunc(
+  "char>?",
+  2,
+  null,
+  make_char_compare_func(function (a, b) {
+    return a > b;
+  })
+);
+define_libfunc(
+  "char<=?",
+  2,
+  null,
+  make_char_compare_func(function (a, b) {
+    return a <= b;
+  })
+);
+define_libfunc(
+  "char>=?",
+  2,
+  null,
+  make_char_compare_func(function (a, b) {
+    return a >= b;
+  })
+);
 
 //
 //        11.12  Strings
 //
-define_libfunc("string?", 1, 1, function(ar){
-  return (typeof(ar[0]) == "string");
-})
-define_libfunc("make-string", 1, 2, function(ar){
+define_libfunc("string?", 1, 1, function (ar) {
+  return typeof ar[0] == "string";
+});
+define_libfunc("make-string", 1, 2, function (ar) {
   assert_integer(ar[0]);
   var c = " ";
-  if(ar[1]){
+  if (ar[1]) {
     assert_char(ar[1]);
     c = ar[1].value;
   }
   var out = "";
-  _.times(ar[0], function() { out += c; });
+  _.times(ar[0], function () {
+    out += c;
+  });
   return out;
-})
-define_libfunc("string", 0, null, function(ar){
-  if(ar.length == 0) return "";
-  for(var i=0; i<ar.length; i++)
-    assert_char(ar[i]);
-  return _.map(ar, function(c){ return c.value }).join("");
-})
-define_libfunc("string-length", 1, 1, function(ar){
+});
+define_libfunc("string", 0, null, function (ar) {
+  if (ar.length == 0) return "";
+  for (var i = 0; i < ar.length; i++) assert_char(ar[i]);
+  return _.map(ar, function (c) {
+    return c.value;
+  }).join("");
+});
+define_libfunc("string-length", 1, 1, function (ar) {
   assert_string(ar[0]);
   return ar[0].length;
-})
-define_libfunc("string-ref", 2, 2, function(ar){
+});
+define_libfunc("string-ref", 2, 2, function (ar) {
   assert_string(ar[0]);
-  assert_between(ar[1], 0, ar[0].length-1);
+  assert_between(ar[1], 0, ar[0].length - 1);
   return Char.get(ar[0].charAt([ar[1]]));
-})
-define_libfunc("string=?", 2, null, function(ar){
+});
+define_libfunc("string=?", 2, null, function (ar) {
   assert_string(ar[0]);
-  for(var i=1; i<ar.length; i++){
+  for (var i = 1; i < ar.length; i++) {
     assert_string(ar[i]);
-    if(ar[0] != ar[i]) return false;
+    if (ar[0] != ar[i]) return false;
   }
   return true;
-})
-define_libfunc("string<?", 2, null, function(ar){
+});
+define_libfunc("string<?", 2, null, function (ar) {
   assert_string(ar[0]);
-  for(var i=1; i<ar.length; i++){
+  for (var i = 1; i < ar.length; i++) {
     assert_string(ar[i]);
-    if(!(ar[i-1] < ar[i])) return false;
+    if (!(ar[i - 1] < ar[i])) return false;
   }
   return true;
-})
-define_libfunc("string>?", 2, null, function(ar){
+});
+define_libfunc("string>?", 2, null, function (ar) {
   assert_string(ar[0]);
-  for(var i=1; i<ar.length; i++){
+  for (var i = 1; i < ar.length; i++) {
     assert_string(ar[i]);
-    if(!(ar[i-1] > ar[i])) return false;
+    if (!(ar[i - 1] > ar[i])) return false;
   }
   return true;
-})
-define_libfunc("string<=?", 2, null, function(ar){
+});
+define_libfunc("string<=?", 2, null, function (ar) {
   assert_string(ar[0]);
-  for(var i=1; i<ar.length; i++){
+  for (var i = 1; i < ar.length; i++) {
     assert_string(ar[i]);
-    if(!(ar[i-1] <= ar[i])) return false;
+    if (!(ar[i - 1] <= ar[i])) return false;
   }
   return true;
-})
-define_libfunc("string>=?", 2, null, function(ar){
+});
+define_libfunc("string>=?", 2, null, function (ar) {
   assert_string(ar[0]);
-  for(var i=1; i<ar.length; i++){
+  for (var i = 1; i < ar.length; i++) {
     assert_string(ar[i]);
-    if(!(ar[i-1] >= ar[i])) return false;
+    if (!(ar[i - 1] >= ar[i])) return false;
   }
   return true;
-})
+});
 
-define_libfunc("substring", 3, 3, function(ar){
+define_libfunc("substring", 3, 3, function (ar) {
   assert_string(ar[0]);
   assert_integer(ar[1]);
   assert_integer(ar[2]);
 
-  if(ar[1] < 0) throw new BiwaError("substring: start too small: "+ar[1]);
-  if(ar[2] < 0) throw new BiwaError("substring: end too small: "+ar[2]);
-  if(ar[0].length+1 <= ar[1]) throw new BiwaError("substring: start too big: "+ar[1]);
-  if(ar[0].length+1 <= ar[2]) throw new BiwaError("substring: end too big: "+ar[2]);
-  if(!(ar[1] <= ar[2])) throw new BiwaError("substring: not start <= end: "+ar[1]+", "+ar[2]);
+  if (ar[1] < 0) throw new BiwaError("substring: start too small: " + ar[1]);
+  if (ar[2] < 0) throw new BiwaError("substring: end too small: " + ar[2]);
+  if (ar[0].length + 1 <= ar[1])
+    throw new BiwaError("substring: start too big: " + ar[1]);
+  if (ar[0].length + 1 <= ar[2])
+    throw new BiwaError("substring: end too big: " + ar[2]);
+  if (!(ar[1] <= ar[2]))
+    throw new BiwaError("substring: not start <= end: " + ar[1] + ", " + ar[2]);
 
   return ar[0].substring(ar[1], ar[2]);
-})
+});
 
-define_libfunc("string-append", 0, null, function(ar){
-  for(var i=0; i<ar.length; i++)
-    assert_string(ar[i]);
+define_libfunc("string-append", 0, null, function (ar) {
+  for (var i = 0; i < ar.length; i++) assert_string(ar[i]);
 
   return ar.join("");
-})
-define_libfunc("string->list", 1, 1, function(ar){
+});
+define_libfunc("string->list", 1, 1, function (ar) {
   assert_string(ar[0]);
-  return array_to_list(_.map(ar[0].split(""), function(s){ return Char.get(s[0]); }));
-})
-define_libfunc("list->string", 1, 1, function(ar){
+  return array_to_list(
+    _.map(ar[0].split(""), function (s) {
+      return Char.get(s[0]);
+    })
+  );
+});
+define_libfunc("list->string", 1, 1, function (ar) {
   assert_list(ar[0]);
-  return _.map(ar[0].to_array(), function(c){ return c.value; }).join("");
-})
-define_libfunc("string-for-each", 2, null, function(ar){
-  var proc = ar.shift(), strs = ar;
-  _.each(strs, assert_string);
+  return _.map(ar[0].to_array(), function (c) {
+    return c.value;
+  }).join("");
+});
+define_libfunc("string-for-each", 2, null, function (ar) {
+  var proc = ar.shift(),
+    strs = ar;
+  strs.forEach(assert_string);
 
   return Call.multi_foreach(strs, {
-    call: function(chars){ return new Call(proc, chars); },
-    finish: function(){ return undef; }
-  })
-})
-define_libfunc("string-copy", 1, 1, function(ar){
+    call: function (chars) {
+      return new Call(proc, chars);
+    },
+    finish: function () {
+      return undef;
+    },
+  });
+});
+define_libfunc("string-copy", 1, 1, function (ar) {
   // note: this is useless, because javascript strings are immutable
   assert_string(ar[0]);
   return ar[0];
-})
-
+});
 
 //
 //        11.13  Vectors
 //
-define_libfunc("vector?", 1, 1, function(ar){
+define_libfunc("vector?", 1, 1, function (ar) {
   return isVector(ar[0]);
-})
-define_libfunc("make-vector", 1, 2, function(ar){
+});
+define_libfunc("make-vector", 1, 2, function (ar) {
   assert_integer(ar[0]);
   var vec = new Array(ar[0]);
 
-  if(ar.length == 2){
-    for(var i=0; i<ar[0]; i++)
-      vec[i] = ar[1];
+  if (ar.length == 2) {
+    for (var i = 0; i < ar[0]; i++) vec[i] = ar[1];
   }
   return vec;
-})
-define_libfunc("vector", 0, null, function(ar){
+});
+define_libfunc("vector", 0, null, function (ar) {
   return ar;
-})
-define_libfunc("vector-length", 1, 1, function(ar){
+});
+define_libfunc("vector-length", 1, 1, function (ar) {
   assert_vector(ar[0]);
   return ar[0].length;
-})
-define_libfunc("vector-ref", 2, 2, function(ar){
+});
+define_libfunc("vector-ref", 2, 2, function (ar) {
   assert_vector(ar[0]);
   assert_integer(ar[1]);
-  assert_between(ar[1], 0, ar[0].length-1);
+  assert_between(ar[1], 0, ar[0].length - 1);
 
   return ar[0][ar[1]];
-})
-define_libfunc("vector-set!", 3, 3, function(ar){
+});
+define_libfunc("vector-set!", 3, 3, function (ar) {
   assert_vector(ar[0]);
   assert_integer(ar[1]);
 
   ar[0][ar[1]] = ar[2];
   return undef;
-})
-define_libfunc("vector->list", 1, 1, function(ar){
+});
+define_libfunc("vector->list", 1, 1, function (ar) {
   assert_vector(ar[0]);
   return array_to_list(ar[0]);
-})
-define_libfunc("list->vector", 1, 1, function(ar){
+});
+define_libfunc("list->vector", 1, 1, function (ar) {
   assert_list(ar[0]);
   return ar[0].to_array();
-})
-define_libfunc("vector-fill!", 2, 2, function(ar){
+});
+define_libfunc("vector-fill!", 2, 2, function (ar) {
   assert_vector(ar[0]);
-  var vec = ar[0], obj = ar[1];
+  var vec = ar[0],
+    obj = ar[1];
 
-  for(var i=0; i<vec.length; i++)
-    vec[i] = obj;
+  for (var i = 0; i < vec.length; i++) vec[i] = obj;
   return vec;
-})
-define_libfunc("vector-map", 2, null, function(ar){
-  var proc = ar.shift(), vecs = ar;
-  _.each(vecs, assert_vector);
+});
+define_libfunc("vector-map", 2, null, function (ar) {
+  var proc = ar.shift(),
+    vecs = ar;
+  vecs.forEach(assert_vector);
 
   var a = [];
   return Call.multi_foreach(vecs, {
-    call: function(objs){ return new Call(proc, objs); },
-    result: function(res){ a.push(res); },
-    finish: function(){ return a; }
-  })
-})
-define_libfunc("vector-for-each", 2, null, function(ar){
-  var proc = ar.shift(), vecs = ar;
-  _.each(vecs, assert_vector);
+    call: function (objs) {
+      return new Call(proc, objs);
+    },
+    result: function (res) {
+      a.push(res);
+    },
+    finish: function () {
+      return a;
+    },
+  });
+});
+define_libfunc("vector-for-each", 2, null, function (ar) {
+  var proc = ar.shift(),
+    vecs = ar;
+  vecs.forEach(assert_vector);
 
   return Call.multi_foreach(vecs, {
-    call: function(objs){ return new Call(proc, objs); },
-    finish: function(){ return undef; }
-  })
-})
+    call: function (objs) {
+      return new Call(proc, objs);
+    },
+    finish: function () {
+      return undef;
+    },
+  });
+});
 
 //
 //        11.14  Errors and violations
@@ -1268,47 +1483,50 @@ define_libfunc("vector-for-each", 2, null, function(ar){
 //
 //        11.15  Control features
 //
-define_libfunc("apply", 2, null, function(ar){
-  var proc = ar.shift(), rest_args = ar.pop(), args = ar;
+define_libfunc("apply", 2, null, function (ar) {
+  var proc = ar.shift(),
+    rest_args = ar.pop(),
+    args = ar;
   args = args.concat(rest_args.to_array());
 
   return new Call(proc, args);
-})
-define_syntax("call-with-current-continuation", function(x){
-  return new Pair(Sym("call/cc"),
-           x.cdr);
-})
-define_libfunc("values", 0, null, function(ar){
-  if (ar.length == 1) // eg. (values 3)
+});
+define_syntax("call-with-current-continuation", function (x) {
+  return new Pair(Sym("call/cc"), x.cdr);
+});
+define_libfunc("values", 0, null, function (ar) {
+  if (ar.length == 1)
+    // eg. (values 3)
     return ar[0];
-  else
-    return new Values(ar);
-})
-define_libfunc("call-with-values", 2, 2, function(ar){
-  var producer = ar[0], consumer = ar[1];
+  else return new Values(ar);
+});
+define_libfunc("call-with-values", 2, 2, function (ar) {
+  var producer = ar[0],
+    consumer = ar[1];
   assert_procedure(producer);
   assert_procedure(consumer);
-  return new Call(producer, [], function(ar){
+  return new Call(producer, [], function (ar) {
     var result = ar[0];
-    if(result instanceof Values){
+    if (result instanceof Values) {
       return new Call(consumer, result.content);
-    }
-    else{
+    } else {
       // eg. (call-with-values (lambda () 3)
       //                       (lambda (x) x))
       return new Call(consumer, [result]);
     }
-  })
-})
+  });
+});
 
-define_libfunc("dynamic-wind", 3, 3, function(ar, intp) {
-  var before = ar[0], thunk = ar[1], after = ar[2];
-  return new Call(before, [], function() {
+define_libfunc("dynamic-wind", 3, 3, function (ar, intp) {
+  var before = ar[0],
+    thunk = ar[1],
+    after = ar[2];
+  return new Call(before, [], function () {
     intp.push_dynamic_winder(before, after);
-    return new Call(thunk, [], function(ar2) {
+    return new Call(thunk, [], function (ar2) {
       var result = ar2[0];
       intp.pop_dynamic_winder();
-      return new Call(after, [], function(){
+      return new Call(after, [], function () {
         return result;
       });
     });
@@ -1321,98 +1539,91 @@ define_libfunc("dynamic-wind", 3, 3, function(ar, intp) {
 //        11.17  Quasiquotation
 // `() is expanded to `cons` and `append`.
 // `#() is expanded to `vector` and `vector-append`.
-var expand_qq = function(f, lv){
-  if(f instanceof BiwaSymbol || f === nil){
+var expand_qq = function (f, lv) {
+  if (f instanceof BiwaSymbol || f === nil) {
     return List(Sym("quote"), f);
-  }
-  else if(f instanceof Pair){
+  } else if (f instanceof Pair) {
     var car = f.car;
-    if(car instanceof Pair && car.car === Sym("unquote-splicing")){
-      if(lv == 1)
-        return List(Sym("append"),
-                    f.car.cdr.car,
-                    expand_qq(f.cdr, lv));
+    if (car instanceof Pair && car.car === Sym("unquote-splicing")) {
+      if (lv == 1)
+        return List(Sym("append"), f.car.cdr.car, expand_qq(f.cdr, lv));
       else
-        return List(Sym("cons"),
-                    List(Sym("list"),
-                         List(Sym("quote"), Sym("unquote-splicing")),
-                         expand_qq(f.car.cdr.car, lv-1)),
-                    expand_qq(f.cdr, lv));
-    }
-    else if(car === Sym("unquote")){
-      if(lv == 1)
-        return f.cdr.car;
+        return List(
+          Sym("cons"),
+          List(
+            Sym("list"),
+            List(Sym("quote"), Sym("unquote-splicing")),
+            expand_qq(f.car.cdr.car, lv - 1)
+          ),
+          expand_qq(f.cdr, lv)
+        );
+    } else if (car === Sym("unquote")) {
+      if (lv == 1) return f.cdr.car;
       else
-        return List(Sym("list"),
-                    List(Sym("quote"), Sym("unquote")),
-                    expand_qq(f.cdr.car, lv-1));
-    }
-    else if(car === Sym("quasiquote"))
-      return List(Sym("list"),
-                  List(Sym("quote"), Sym("quasiquote")),
-                  expand_qq(f.cdr.car, lv+1));
-    else
-      return List(Sym("cons"),
-                  expand_qq(f.car, lv),
-                  expand_qq(f.cdr, lv));
-  }
-  else if(f instanceof Array){
+        return List(
+          Sym("list"),
+          List(Sym("quote"), Sym("unquote")),
+          expand_qq(f.cdr.car, lv - 1)
+        );
+    } else if (car === Sym("quasiquote"))
+      return List(
+        Sym("list"),
+        List(Sym("quote"), Sym("quasiquote")),
+        expand_qq(f.cdr.car, lv + 1)
+      );
+    else return List(Sym("cons"), expand_qq(f.car, lv), expand_qq(f.cdr, lv));
+  } else if (f instanceof Array) {
     var vecs = [[]];
-    for(var i=0; i<f.length; i++){
-      if(f[i] instanceof Pair && f[i].car === Sym("unquote-splicing")) {
+    for (var i = 0; i < f.length; i++) {
+      if (f[i] instanceof Pair && f[i].car === Sym("unquote-splicing")) {
         if (lv == 1) {
           var item = List(Sym("list->vector"), f[i].cdr.car);
           item["splicing"] = true;
           vecs.push(item);
           vecs.push([]);
-        }
-        else {
-          var item = List(Sym("cons"),
-                       List(Sym("list"),
-                            List(Sym("quote"), Sym("unquote-splicing")),
-                            expand_qq(f[i].car.cdr.car, lv-1)),
-                       expand_qq(f[i].cdr, lv));
+        } else {
+          var item = List(
+            Sym("cons"),
+            List(
+              Sym("list"),
+              List(Sym("quote"), Sym("unquote-splicing")),
+              expand_qq(f[i].car.cdr.car, lv - 1)
+            ),
+            expand_qq(f[i].cdr, lv)
+          );
           _.last(vecs).push(item);
         }
-      }
-      else {
+      } else {
         // Expand other things as the same as if they are in a list quasiquote
         _.last(vecs).push(expand_qq(f[i], lv));
       }
     }
 
-    var vectors = vecs.map(function(vec){
+    var vectors = vecs.map(function (vec) {
       if (vec["splicing"]) {
         return vec;
-      }
-      else {
-        return Cons(Sym("vector"),
-                    array_to_list(vec));
+      } else {
+        return Cons(Sym("vector"), array_to_list(vec));
       }
     });
     if (vectors.length == 1) {
-       return Cons(Sym("vector"),
-                   array_to_list(vecs[0]));
+      return Cons(Sym("vector"), array_to_list(vecs[0]));
+    } else {
+      return Cons(Sym("vector-append"), array_to_list(vectors));
     }
-    else {
-      return Cons(Sym("vector-append"),
-                  array_to_list(vectors));
-    }
-  }
-  else
-    return f;
-}
-define_syntax("quasiquote", function(x){
+  } else return f;
+};
+define_syntax("quasiquote", function (x) {
   return expand_qq(x.cdr.car, 1);
-})
+});
 //unquote
-define_syntax("unquote", function(x){
+define_syntax("unquote", function (x) {
   throw new BiwaError("unquote(,) must be inside quasiquote(`)");
-})
+});
 //unquote-splicing
-define_syntax("unquote-splicing", function(x){
+define_syntax("unquote-splicing", function (x) {
   throw new BiwaError("unquote-splicing(,@) must be inside quasiquote(`)");
-})
+});
 
 //        11.18  Binding constructs for syntactic keywords
 //let-syntax
@@ -1425,7 +1636,6 @@ define_syntax("unquote-splicing", function(x){
 
 //        11.20  Tail calls and tail contexts
 //(no library function introduced)
-
 
 ///
 /// R6RS Standard Libraries
@@ -1455,46 +1665,75 @@ define_syntax("unquote-splicing", function(x){
 //(char-general-category char)    procedure
 
 //(string-upcase string)    procedure
-define_libfunc("string-upcase", 1, 1, function(ar){
+define_libfunc("string-upcase", 1, 1, function (ar) {
   assert_string(ar[0]);
   return ar[0].toUpperCase();
 });
 //(string-downcase string)    procedure
-define_libfunc("string-downcase", 1, 1, function(ar){
+define_libfunc("string-downcase", 1, 1, function (ar) {
   assert_string(ar[0]);
   return ar[0].toLowerCase();
 });
 //(string-titlecase string)    procedure
 //(string-foldcase string)    procedure
 
-const make_string_ci_function = function(compare){
-  return function(ar){
+const make_string_ci_function = function (compare) {
+  return function (ar) {
     assert_string(ar[0]);
     var str = ar[0].toUpperCase();
 
-    for(var i=1; i<ar.length; i++){
+    for (var i = 1; i < ar.length; i++) {
       assert_string(ar[i]);
-      if (!compare(str, ar[i].toUpperCase()))
-        return false;
+      if (!compare(str, ar[i].toUpperCase())) return false;
     }
     return true;
-  }
+  };
 };
 //(string-ci=? string1 string2 string3 ...)    procedure
-define_libfunc("string-ci=?", 2, null,
-  make_string_ci_function(function(a, b){ return a == b; }));
+define_libfunc(
+  "string-ci=?",
+  2,
+  null,
+  make_string_ci_function(function (a, b) {
+    return a == b;
+  })
+);
 //(string-ci<? string1 string2 string3 ...)    procedure
-define_libfunc("string-ci<?", 2, null,
-  make_string_ci_function(function(a, b){ return a < b; }));
+define_libfunc(
+  "string-ci<?",
+  2,
+  null,
+  make_string_ci_function(function (a, b) {
+    return a < b;
+  })
+);
 //(string-ci>? string1 string2 string3 ...)    procedure
-define_libfunc("string-ci>?", 2, null,
-  make_string_ci_function(function(a, b){ return a > b; }));
+define_libfunc(
+  "string-ci>?",
+  2,
+  null,
+  make_string_ci_function(function (a, b) {
+    return a > b;
+  })
+);
 //(string-ci<=? string1 string2 string3 ...)    procedure
-define_libfunc("string-ci<=?", 2, null,
-  make_string_ci_function(function(a, b){ return a <= b; }));
+define_libfunc(
+  "string-ci<=?",
+  2,
+  null,
+  make_string_ci_function(function (a, b) {
+    return a <= b;
+  })
+);
 //(string-ci>=? string1 string2 string3 ...)    procedure
-define_libfunc("string-ci>=?", 2, null,
-  make_string_ci_function(function(a, b){ return a >= b; }));
+define_libfunc(
+  "string-ci>=?",
+  2,
+  null,
+  make_string_ci_function(function (a, b) {
+    return a >= b;
+  })
+);
 
 //(string-normalize-nfd string)    procedure
 //(string-normalize-nfkd string)    procedure
@@ -1508,58 +1747,86 @@ define_libfunc("string-ci>=?", 2, null,
 //
 // Chapter 3 List utilities
 //
-define_libfunc("find", 2, 2, function(ar){
-  var proc = ar[0], ls = ar[1];
+define_libfunc("find", 2, 2, function (ar) {
+  var proc = ar[0],
+    ls = ar[1];
   assert_list(ls);
   return Call.foreach(ls, {
-    call: function(x){ return new Call(proc, [x.car]) },
-    result: function(res, x){ if(res) return x.car; },
-    finish: function(){ return false }
-  })
-})
-define_libfunc("for-all", 2, null, function(ar){
+    call: function (x) {
+      return new Call(proc, [x.car]);
+    },
+    result: function (res, x) {
+      if (res) return x.car;
+    },
+    finish: function () {
+      return false;
+    },
+  });
+});
+define_libfunc("for-all", 2, null, function (ar) {
   var proc = ar.shift();
   var lists = ar;
-  _.each(lists, assert_list);
+  lists.forEach(assert_list);
 
   var last = true; //holds last result which proc returns
   return Call.multi_foreach(lists, {
-    call: function(pairs){
-      return new Call(proc, _.map(pairs, function(x){ return x.car }));
+    call: function (pairs) {
+      return new Call(
+        proc,
+        _.map(pairs, function (x) {
+          return x.car;
+        })
+      );
     },
-    result: function(res, pairs){
-      if(res === false) return false;
+    result: function (res, pairs) {
+      if (res === false) return false;
       last = res;
     },
-    finish: function(){ return last; }
-  })
-})
-define_libfunc("exists", 2, null, function(ar){
+    finish: function () {
+      return last;
+    },
+  });
+});
+define_libfunc("exists", 2, null, function (ar) {
   var proc = ar.shift();
   var lists = ar;
-  _.each(lists, assert_list);
+  lists.forEach(assert_list);
 
   return Call.multi_foreach(lists, {
-    call: function(pairs){
-      return new Call(proc, _.map(pairs, function(x){ return x.car }));
+    call: function (pairs) {
+      return new Call(
+        proc,
+        _.map(pairs, function (x) {
+          return x.car;
+        })
+      );
     },
-    result: function(res, pairs){
-      if(res !== false) return res;
+    result: function (res, pairs) {
+      if (res !== false) return res;
     },
-    finish: function(){ return false; }
-  })
-})
-define_libfunc("filter", 2, 2, function(ar){
-  var proc = ar[0], ls = ar[1];
+    finish: function () {
+      return false;
+    },
+  });
+});
+define_libfunc("filter", 2, 2, function (ar) {
+  var proc = ar[0],
+    ls = ar[1];
   assert_list(ls);
 
   var a = [];
   return Call.foreach(ls, {
-    call: function(x){ return new Call(proc, [x.car]) },
-    result: function(res, x){ if(res) a.push(x.car); },
-    finish: function(){ return array_to_list(a) }
-  })
-})
+    call: function (x) {
+      return new Call(proc, [x.car]);
+    },
+    result: function (res, x) {
+      if (res) a.push(x.car);
+    },
+    finish: function () {
+      return array_to_list(a);
+    },
+  });
+});
 //  define_scmfunc("partition+", 2, 2,
 //    "(lambda (proc ls)  \
 //       (define (partition2 proc ls t f) \
@@ -1570,165 +1837,216 @@ define_libfunc("filter", 2, 2, function(ar){
 //             (partition2 proc (cdr ls) t (cons (car ls) f))))) \
 //       (partition2 proc ls '() '()))");
 
-define_libfunc("partition", 2, 2, function(ar){
-  var proc = ar[0], ls = ar[1];
+define_libfunc("partition", 2, 2, function (ar) {
+  var proc = ar[0],
+    ls = ar[1];
   assert_list(ls);
 
-  var t = [], f = [];
+  var t = [],
+    f = [];
   return Call.foreach(ls, {
-    call: function(x){ return new Call(proc, [x.car]) },
-    result: function(res, x){
-      if(res) t.push(x.car);
-      else    f.push(x.car);
+    call: function (x) {
+      return new Call(proc, [x.car]);
     },
-    finish: function(){
+    result: function (res, x) {
+      if (res) t.push(x.car);
+      else f.push(x.car);
+    },
+    finish: function () {
       return new Values([array_to_list(t), array_to_list(f)]);
-    }
-  })
-})
-define_libfunc("fold-left", 3, null, function(ar){
-  var proc = ar.shift(), accum = ar.shift(), lists = ar;
-  _.each(lists, assert_list);
+    },
+  });
+});
+define_libfunc("fold-left", 3, null, function (ar) {
+  var proc = ar.shift(),
+    accum = ar.shift(),
+    lists = ar;
+  lists.forEach(assert_list);
 
   return Call.multi_foreach(lists, {
-    call: function(pairs){
-      var args = _.map(pairs, function(x){ return x.car });
+    call: function (pairs) {
+      var args = _.map(pairs, function (x) {
+        return x.car;
+      });
       args.unshift(accum);
       return new Call(proc, args);
     },
-    result: function(res, pairs){ accum = res; },
-    finish: function(){ return accum; }
-  })
-})
-define_libfunc("fold-right", 3, null, function(ar){
-  var proc = ar.shift(), accum = ar.shift();
-  var lists = _.map(ar, function(ls){
+    result: function (res, pairs) {
+      accum = res;
+    },
+    finish: function () {
+      return accum;
+    },
+  });
+});
+define_libfunc("fold-right", 3, null, function (ar) {
+  var proc = ar.shift(),
+    accum = ar.shift();
+  var lists = _.map(ar, function (ls) {
     // reverse each list
     assert_list(ls);
     return array_to_list(ls.to_array().reverse());
-  })
+  });
 
   return Call.multi_foreach(lists, {
-    call: function(pairs){
-      var args = _.map(pairs, function(x){ return x.car });
+    call: function (pairs) {
+      var args = _.map(pairs, function (x) {
+        return x.car;
+      });
       args.push(accum);
       return new Call(proc, args);
     },
-    result: function(res, pairs){ accum = res; },
-    finish: function(){ return accum; }
-  })
-})
-define_libfunc("remp", 2, 2, function(ar){
-  var proc = ar[0], ls = ar[1];
+    result: function (res, pairs) {
+      accum = res;
+    },
+    finish: function () {
+      return accum;
+    },
+  });
+});
+define_libfunc("remp", 2, 2, function (ar) {
+  var proc = ar[0],
+    ls = ar[1];
   assert_list(ls);
 
   var ret = [];
   return Call.foreach(ls, {
-    call: function(x){ return new Call(proc, [x.car]) },
-    result: function(res, x){ if(!res) ret.push(x.car); },
-    finish: function(){ return array_to_list(ret); }
-  })
-})
-var make_remover = function(key){
-  return function(ar){
-    var obj = ar[0], ls = ar[1];
+    call: function (x) {
+      return new Call(proc, [x.car]);
+    },
+    result: function (res, x) {
+      if (!res) ret.push(x.car);
+    },
+    finish: function () {
+      return array_to_list(ret);
+    },
+  });
+});
+var make_remover = function (key) {
+  return function (ar) {
+    var obj = ar[0],
+      ls = ar[1];
     assert_list(ls);
 
     var ret = [];
     return Call.foreach(ls, {
-      call: function(x){
-        return new Call(TopEnv[key] || CoreEnv[key], [obj, x.car])
+      call: function (x) {
+        return new Call(TopEnv[key] || CoreEnv[key], [obj, x.car]);
       },
-      result: function(res, x){ if(!res) ret.push(x.car); },
-      finish: function(){ return array_to_list(ret); }
-    })
-  }
-}
+      result: function (res, x) {
+        if (!res) ret.push(x.car);
+      },
+      finish: function () {
+        return array_to_list(ret);
+      },
+    });
+  };
+};
 define_libfunc("remove", 2, 2, make_remover("equal?"));
 define_libfunc("remv", 2, 2, make_remover("eqv?"));
 define_libfunc("remq", 2, 2, make_remover("eq?"));
 
-define_libfunc("memp", 2, 2, function(ar){
-  var proc = ar[0], ls = ar[1];
+define_libfunc("memp", 2, 2, function (ar) {
+  var proc = ar[0],
+    ls = ar[1];
   assert_list(ls);
 
   var ret = [];
   return Call.foreach(ls, {
-    call: function(x){ return new Call(proc, [x.car]) },
-    result: function(res, x){ if(res) return x; },
-    finish: function(){ return false; }
-  })
-})
-var make_finder = function(key){
-  return function(ar){
-    var obj = ar[0], ls = ar[1];
+    call: function (x) {
+      return new Call(proc, [x.car]);
+    },
+    result: function (res, x) {
+      if (res) return x;
+    },
+    finish: function () {
+      return false;
+    },
+  });
+});
+var make_finder = function (key) {
+  return function (ar) {
+    var obj = ar[0],
+      ls = ar[1];
     assert_list(ls);
 
     var ret = [];
     return Call.foreach(ls, {
-      call: function(x){
-        return new Call(TopEnv[key] || CoreEnv[key], [obj, x.car])
+      call: function (x) {
+        return new Call(TopEnv[key] || CoreEnv[key], [obj, x.car]);
       },
-      result: function(res, x){ if(res) return x; },
-      finish: function(){ return false; }
-    })
-  }
-}
+      result: function (res, x) {
+        if (res) return x;
+      },
+      finish: function () {
+        return false;
+      },
+    });
+  };
+};
 define_libfunc("member", 2, 2, make_finder("equal?"));
 define_libfunc("memv", 2, 2, make_finder("eqv?"));
 define_libfunc("memq", 2, 2, make_finder("eq?"));
 
-define_libfunc("assp", 2, 2, function(ar){
-  var proc = ar[0], als = ar[1];
+define_libfunc("assp", 2, 2, function (ar) {
+  var proc = ar[0],
+    als = ar[1];
   assert_list(als);
 
   var ret = [];
   return Call.foreach(als, {
-    call: function(x){
-      if(x.car.car)
-        return new Call(proc, [x.car.car]);
+    call: function (x) {
+      if (x.car.car) return new Call(proc, [x.car.car]);
       else
-        throw new BiwaError("ass*: pair required but got "+to_write(x.car));
+        throw new BiwaError("ass*: pair required but got " + to_write(x.car));
     },
-    result: function(res, x){ if(res) return x.car; },
-    finish: function(){ return false; }
-  })
-})
-var make_assoc = function(func_name, eq_func_name){
-  return function(ar){
-    var obj = ar[0], list = ar[1];
+    result: function (res, x) {
+      if (res) return x.car;
+    },
+    finish: function () {
+      return false;
+    },
+  });
+});
+var make_assoc = function (func_name, eq_func_name) {
+  return function (ar) {
+    var obj = ar[0],
+      list = ar[1];
     assert_list(list);
 
     var ret = [];
     return Call.foreach(list, {
-      call: function(ls){
-        if(!isPair(ls.car))
-          throw new BiwaError(func_name+": pair required but got "+to_write(ls.car));
+      call: function (ls) {
+        if (!isPair(ls.car))
+          throw new BiwaError(
+            func_name + ": pair required but got " + to_write(ls.car)
+          );
 
-        var equality = (TopEnv[eq_func_name] || CoreEnv[eq_func_name]);
+        var equality = TopEnv[eq_func_name] || CoreEnv[eq_func_name];
         return new Call(equality, [obj, ls.car.car]);
       },
-      result: function(was_equal, ls){ if(was_equal) return ls.car; },
-      finish: function(){ return false; }
-    })
-  }
-}
+      result: function (was_equal, ls) {
+        if (was_equal) return ls.car;
+      },
+      finish: function () {
+        return false;
+      },
+    });
+  };
+};
 define_libfunc("assoc", 2, 2, make_assoc("assoc", "equal?"));
 define_libfunc("assv", 2, 2, make_assoc("assv", "eqv?"));
 define_libfunc("assq", 2, 2, make_assoc("assq", "eq?"));
 
-define_libfunc("cons*", 1, null, function(ar){
-  if(ar.length == 1)
-    return ar[0];
-  else{
+define_libfunc("cons*", 1, null, function (ar) {
+  if (ar.length == 1) return ar[0];
+  else {
     var ret = null;
-    _.each(ar.reverse(), function(x){
-      if(ret){
+    ar.reverse().forEach(function (x) {
+      if (ret) {
         ret = new Pair(x, ret);
-      }
-      else
-        ret = x;
-    })
+      } else ret = x;
+    });
     return ret;
   }
 });
@@ -1736,39 +2054,40 @@ define_libfunc("cons*", 1, null, function(ar){
 //
 // Chapter 4 Sorting
 //
-(function(){
+(function () {
   // Destructively sort the given array
   // with scheme function `proc` as comparator
-  var mergeSort = function(ary, proc, finish) {
+  var mergeSort = function (ary, proc, finish) {
     if (ary.length <= 1) return finish(ary);
     return mergeSort_(ary, proc, finish, [[0, ary.length, false]], false);
   };
 
-  var mergeSort_ = function(ary, proc, finish, stack, up) {
-    while(true) {
-      var start = stack[stack.length-1][0],
-          end   = stack[stack.length-1][1],
-          left  = stack[stack.length-1][2];
+  var mergeSort_ = function (ary, proc, finish, stack, up) {
+    while (true) {
+      var start = stack[stack.length - 1][0],
+        end = stack[stack.length - 1][1],
+        left = stack[stack.length - 1][2];
       var len = end - start;
       //console.debug("mergeSort_", ary, stack.join(' '), up?"u":"d", ""+start+".."+(end-1))
 
       if (len >= 2 && !up) {
         // There are parts to be sorted
-        stack.push([start, start+(len>>1), true]); continue;
-      }
-      else if (left) {
+        stack.push([start, start + (len >> 1), true]);
+        continue;
+      } else if (left) {
         // Left part sorted. Continue to the right one
         stack.pop();
-        var rend = stack[stack.length-1][1];
-        stack.push([end, rend, false]); up = false; continue;
-      }
-      else {
+        var rend = stack[stack.length - 1][1];
+        stack.push([end, rend, false]);
+        up = false;
+        continue;
+      } else {
         // Right part sorted. Merge left and right
         stack.pop();
-        var lstart = stack[stack.length-1][0];
+        var lstart = stack[stack.length - 1][0];
         var ary1 = ary.slice(lstart, start),
-            ary2 = ary.slice(start, end);
-        return merge_(ary1, ary2, proc, [], 0, 0, function(ret) {
+          ary2 = ary.slice(start, end);
+        return merge_(ary1, ary2, proc, [], 0, 0, function (ret) {
           //console.debug("mergeSortd", ary, stack.join(' '), up?"u":"d", ary1, ary2, ret, ""+start+".."+(start+len-1));
           for (var i = 0; i < ret.length; i++) {
             ary[lstart + i] = ret[i];
@@ -1776,8 +2095,7 @@ define_libfunc("cons*", 1, null, function(ar){
 
           if (stack.length == 1) {
             return finish(ary);
-          }
-          else {
+          } else {
             return mergeSort_(ary, proc, finish, stack, true);
           }
         });
@@ -1785,72 +2103,75 @@ define_libfunc("cons*", 1, null, function(ar){
     }
   };
 
-  var merge_ = function(ary1, ary2, proc, ret, i, j, cont) {
+  var merge_ = function (ary1, ary2, proc, ret, i, j, cont) {
     //console.debug("merge_", ary1, ary2, ret, i, j);
-    var len1 = ary1.length, len2 = ary2.length;
+    var len1 = ary1.length,
+      len2 = ary2.length;
     if (i < len1 && j < len2) {
-      return new Call(proc, [ary2[j], ary1[i]], function(ar) {
+      return new Call(proc, [ary2[j], ary1[i]], function (ar) {
         //console.debug("comp", [ary2[j], ary1[i]], ar[0]);
         if (ar[0]) {
-          ret.push(ary2[j]); j+=1;
-        }
-        else {
-          ret.push(ary1[i]); i+=1;
+          ret.push(ary2[j]);
+          j += 1;
+        } else {
+          ret.push(ary1[i]);
+          i += 1;
         }
         return merge_(ary1, ary2, proc, ret, i, j, cont);
       });
-    }
-    else {
-      while (i < len1) { ret.push(ary1[i]); i+=1; }
-      while (j < len2) { ret.push(ary2[j]); j+=1; }
-      return cont(ret)
+    } else {
+      while (i < len1) {
+        ret.push(ary1[i]);
+        i += 1;
+      }
+      while (j < len2) {
+        ret.push(ary2[j]);
+        j += 1;
+      }
+      return cont(ret);
     }
   };
 
-  var compareFn = function(a,b){
-    return lt(a, b) ? -1 :
-           lt(b, a) ? 1 : 0;
+  var compareFn = function (a, b) {
+    return lt(a, b) ? -1 : lt(b, a) ? 1 : 0;
   };
 
-  define_libfunc("list-sort", 1, 2, function(ar){
-    if(ar[1]){
+  define_libfunc("list-sort", 1, 2, function (ar) {
+    if (ar[1]) {
       assert_procedure(ar[0]);
       assert_list(ar[1]);
-      return mergeSort(ar[1].to_array(), ar[0], function(ret) {
+      return mergeSort(ar[1].to_array(), ar[0], function (ret) {
         return array_to_list(ret);
       });
-    }
-    else {
+    } else {
       assert_list(ar[0]);
       return array_to_list(ar[0].to_array().sort(compareFn));
     }
   });
 
   //(vector-sort proc vector)    procedure
-  define_libfunc("vector-sort", 1, 2, function(ar){
-    if(ar[1]){
+  define_libfunc("vector-sort", 1, 2, function (ar) {
+    if (ar[1]) {
       assert_procedure(ar[0]);
       assert_vector(ar[1]);
-      return mergeSort(_.clone(ar[1]), ar[0], function(ret){
+      return mergeSort(_.clone(ar[1]), ar[0], function (ret) {
         return ret;
       });
-    }
-    else {
+    } else {
       assert_vector(ar[0]);
       return _.clone(ar[0]).sort(compareFn);
     }
   });
 
   //(vector-sort! proc vector)    procedure
-  define_libfunc("vector-sort!", 1, 2, function(ar){
-    if(ar[1]){
+  define_libfunc("vector-sort!", 1, 2, function (ar) {
+    if (ar[1]) {
       assert_procedure(ar[0]);
       assert_vector(ar[1]);
-      return mergeSort(ar[1], ar[0], function(ret) {
+      return mergeSort(ar[1], ar[0], function (ret) {
         return undef;
       });
-    }
-    else {
+    } else {
       assert_vector(ar[0]);
       ar[0].sort(compareFn);
       return undef;
@@ -1861,29 +2182,34 @@ define_libfunc("cons*", 1, null, function(ar){
 //
 // Chapter 5 Control Structures
 //
-define_syntax("when", function(x){
+define_syntax("when", function (x) {
   //(when test body ...)
   //=> (if test (begin body ...) #<undef>)
-  var test = x.cdr.car, body = x.cdr.cdr;
+  var test = x.cdr.car,
+    body = x.cdr.cdr;
 
-  return new Pair(Sym("if"),
-           new Pair(test,
-             new Pair(new Pair(Sym("begin"), body),
-               new Pair(undef, nil))));
+  return new Pair(
+    Sym("if"),
+    new Pair(test, new Pair(new Pair(Sym("begin"), body), new Pair(undef, nil)))
+  );
 });
 
-define_syntax("unless", function(x){
+define_syntax("unless", function (x) {
   //(unless test body ...)
   //=> (if (not test) (begin body ...) #<undef>)
-  var test = x.cdr.car, body = x.cdr.cdr;
+  var test = x.cdr.car,
+    body = x.cdr.cdr;
 
-  return new Pair(Sym("if"),
-           new Pair(new Pair(Sym("not"), new Pair(test, nil)),
-             new Pair(new Pair(Sym("begin"), body),
-               new Pair(undef, nil))));
+  return new Pair(
+    Sym("if"),
+    new Pair(
+      new Pair(Sym("not"), new Pair(test, nil)),
+      new Pair(new Pair(Sym("begin"), body), new Pair(undef, nil))
+    )
+  );
 });
 
-define_syntax("do", function(x){
+define_syntax("do", function (x) {
   //(do ((var1 init1 step1)
   //     (var2 init2 step2) ...)
   //    (test expr1 expr2 ...)
@@ -1895,85 +2221,90 @@ define_syntax("do", function(x){
   //              (loop` step1 step2 ...)))))
 
   // parse arguments
-  if(!isPair(x.cdr))
-    throw new BiwaError("do: no variables of do");
+  if (!isPair(x.cdr)) throw new BiwaError("do: no variables of do");
   var varsc = x.cdr.car;
-  if(!isPair(varsc))
+  if (!isPair(varsc))
     throw new BiwaError("do: variables must be given as a list");
-  if(!isPair(x.cdr.cdr))
-    throw new BiwaError("do: no resulting form of do");
+  if (!isPair(x.cdr.cdr)) throw new BiwaError("do: no resulting form of do");
   var resultc = x.cdr.cdr.car;
   var bodyc = x.cdr.cdr.cdr;
 
   // construct subforms
   var loop = gensym();
 
-  var init_vars = array_to_list(varsc.map(function(var_def){
-    var a = var_def.to_array();
-    return List(a[0], a[1]);
-  }));
+  var init_vars = array_to_list(
+    varsc.map(function (var_def) {
+      var a = var_def.to_array();
+      return List(a[0], a[1]);
+    })
+  );
 
   var test = resultc.car;
   var result_exprs = new Pair(Sym("begin"), resultc.cdr);
 
-  var next_loop = new Pair(loop, array_to_list(varsc.map(function(var_def){
-    var a = var_def.to_array();
-    return a[2] || a[0];
-  })));
+  var next_loop = new Pair(
+    loop,
+    array_to_list(
+      varsc.map(function (var_def) {
+        var a = var_def.to_array();
+        return a[2] || a[0];
+      })
+    )
+  );
   var body_exprs = new Pair(Sym("begin"), bodyc).concat(List(next_loop));
 
   // combine subforms
-  return List(Sym("let"),
-              loop,
-              init_vars,
-              List(Sym("if"),
-                   test,
-                   result_exprs,
-                   body_exprs));
+  return List(
+    Sym("let"),
+    loop,
+    init_vars,
+    List(Sym("if"), test, result_exprs, body_exprs)
+  );
 });
 
 //(case-lambda <case-lambda clause> ...)    syntax
-define_syntax("case-lambda", function(x){
-  if(!isPair(x.cdr))
+define_syntax("case-lambda", function (x) {
+  if (!isPair(x.cdr))
     throw new BiwaError("case-lambda: at least 1 clause required");
   var clauses = x.cdr.to_array();
-  
+
   var args_ = gensym();
   var exec = List(Sym("raise"), "case-lambda: no matching clause found");
 
-  clauses.reverse().forEach(function(clause) {
-    if(!isPair(clause))
-      throw new BiwaError("case-lambda: clause must be a pair: "+
-                      to_write(clause));
-    var formals = clause.car, clause_body = clause.cdr;
+  clauses.reverse().forEach(function (clause) {
+    if (!isPair(clause))
+      throw new BiwaError(
+        "case-lambda: clause must be a pair: " + to_write(clause)
+      );
+    var formals = clause.car,
+      clause_body = clause.cdr;
 
     if (formals === nil) {
-      exec = List(Sym("if"),
-                  List(Sym("null?"), args_),
-                  new Pair(Sym("begin"), clause_body),
-                  exec);
-    }
-    else if (isPair(formals)) {
-      var len = formals.length(), last_cdr = formals.last_cdr();
-      var pred = (last_cdr === nil ? Sym("=") : Sym(">="));
-      var lambda = new Pair(Sym("lambda"),
-                     new Pair(formals,
-                       clause_body));
-      exec = List(Sym("if"),
-                  List(pred, List(Sym("length"), args_), len),
-                  List(Sym("apply"), lambda, args_),
-                  exec);
-    }
-    else if (isSymbol(formals)) {
-      exec = new Pair(Sym("let1"),
-               new Pair(formals,
-                 new Pair(args_,
-                   clause_body)));
+      exec = List(
+        Sym("if"),
+        List(Sym("null?"), args_),
+        new Pair(Sym("begin"), clause_body),
+        exec
+      );
+    } else if (isPair(formals)) {
+      var len = formals.length(),
+        last_cdr = formals.last_cdr();
+      var pred = last_cdr === nil ? Sym("=") : Sym(">=");
+      var lambda = new Pair(Sym("lambda"), new Pair(formals, clause_body));
+      exec = List(
+        Sym("if"),
+        List(pred, List(Sym("length"), args_), len),
+        List(Sym("apply"), lambda, args_),
+        exec
+      );
+    } else if (isSymbol(formals)) {
+      exec = new Pair(
+        Sym("let1"),
+        new Pair(formals, new Pair(args_, clause_body))
+      );
       // Note: previous `exec` is just discarded because this is a wildcard pattern.
-    }
-    else {
-      throw new BiwaError("case-lambda: invalid formals: "+
-                      to_write(formals));
+    } else {
+      throw new BiwaError("case-lambda: invalid formals: " + to_write(formals));
     }
   });
 
@@ -1989,7 +2320,7 @@ define_syntax("case-lambda", function(x){
 //eqv, eq
 
 //(define-record-type <name spec> <record clause>*)    syntax
-define_syntax("define-record-type", function(x){
+define_syntax("define-record-type", function (x) {
   // (define-record-type <name spec> <record clause>*)
   var name_spec = x.cdr.car;
   var record_clauses = x.cdr.cdr;
@@ -1999,12 +2330,11 @@ define_syntax("define-record-type", function(x){
   // - <record name> eg: point
   // - (<record name> <constructor name> <predicate name>)
   //   eg: (point make-point point?)
-  if(isSymbol(name_spec)){
+  if (isSymbol(name_spec)) {
     var record_name = name_spec;
-    var constructor_name = Sym("make-"+name_spec.name);
-    var predicate_name = Sym(name_spec.name+"?");
-  }
-  else{
+    var constructor_name = Sym("make-" + name_spec.name);
+    var predicate_name = Sym(name_spec.name + "?");
+  } else {
     assert_list(name_spec);
     var record_name = name_spec.car;
     var constructor_name = name_spec.cdr.car;
@@ -2026,31 +2356,39 @@ define_syntax("define-record-type", function(x){
   var fields = [];
 
   // <record clause>:
-  _.each(record_clauses.to_array(), function(clause){
-    switch(clause.car){
+  record_clauses.to_array().forEach(function (clause) {
+    switch (clause.car) {
       // - (fields <field spec>*)
       case Sym("fields"):
-        fields = _.map(clause.cdr.to_array(), function(field_spec, idx){
-          if(isSymbol(field_spec)){
+        fields = _.map(clause.cdr.to_array(), function (field_spec, idx) {
+          if (isSymbol(field_spec)) {
             // - <field name>
-            return {name: field_spec, idx: idx, mutable: false,
-                    accessor_name: null, mutator_name: null};
-          }
-          else{
+            return {
+              name: field_spec,
+              idx: idx,
+              mutable: false,
+              accessor_name: null,
+              mutator_name: null,
+            };
+          } else {
             assert_list(field_spec);
             assert_symbol(field_spec.car);
-            switch(field_spec.car){
+            switch (field_spec.car) {
               case Sym("immutable"):
                 // - (immutable <field name>)
                 // - (immutable <field name> <accessor name>)
                 var field_name = field_spec.cdr.car;
                 assert_symbol(field_name);
 
-                if(isNil(field_spec.cdr.cdr))
-                  return {name: field_name, idx: idx, mutable: false};
+                if (isNil(field_spec.cdr.cdr))
+                  return { name: field_name, idx: idx, mutable: false };
                 else
-                  return {name: field_name, idx: idx, mutable: false,
-                          accessor_name: field_spec.cdr.cdr.car};
+                  return {
+                    name: field_name,
+                    idx: idx,
+                    mutable: false,
+                    accessor_name: field_spec.cdr.cdr.car,
+                  };
                 break;
 
               case Sym("mutable"):
@@ -2059,17 +2397,24 @@ define_syntax("define-record-type", function(x){
                 var field_name = field_spec.cdr.car;
                 assert_symbol(field_name);
 
-                if(isNil(field_spec.cdr.cdr))
-                  return {name: field_name, idx: idx, mutable: true}
+                if (isNil(field_spec.cdr.cdr))
+                  return { name: field_name, idx: idx, mutable: true };
                 else
-                  return {name: field_name, idx: idx, mutable: true,
-                          accessor_name: field_spec.cdr.cdr.car,
-                          mutator_name:  field_spec.cdr.cdr.cdr.car};
+                  return {
+                    name: field_name,
+                    idx: idx,
+                    mutable: true,
+                    accessor_name: field_spec.cdr.cdr.car,
+                    mutator_name: field_spec.cdr.cdr.cdr.car,
+                  };
                 break;
               default:
-                throw new BiwaError("define-record-type: field definition "+
-                            "must start with `immutable' or `mutable' "+
-                            "but got "+inspect(field_spec.car));
+                throw new BiwaError(
+                  "define-record-type: field definition " +
+                    "must start with `immutable' or `mutable' " +
+                    "but got " +
+                    inspect(field_spec.car)
+                );
             }
           }
         });
@@ -2102,14 +2447,15 @@ define_syntax("define-record-type", function(x){
         parent_cd = clause.cdr.cdr.car;
         break;
       default:
-        throw new BiwaError("define-record-type: unknown clause `"+
-                                   to_write(clause.car)+"'");
+        throw new BiwaError(
+          "define-record-type: unknown clause `" + to_write(clause.car) + "'"
+        );
     }
   });
 
-  if(parent_name){
+  if (parent_name) {
     parent_rtd = [Sym("record-type-descriptor"), parent_name];
-    parent_cd  = [Sym("record-constructor-descriptor"), parent_name];
+    parent_cd = [Sym("record-constructor-descriptor"), parent_name];
   }
 
   // 3. build the definitions
@@ -2118,38 +2464,57 @@ define_syntax("define-record-type", function(x){
   // and record-constructor-descriptor. These relation are stored in
   // the hash BiwaScheme.Record._DefinedTypes.
   var rtd = [Sym("record-type-descriptor"), record_name];
-  var cd  = [Sym("record-constructor-descriptor"), record_name];
+  var cd = [Sym("record-constructor-descriptor"), record_name];
 
   // registration
-  var rtd_fields = _.map(fields, function(field){
+  var rtd_fields = _.map(fields, function (field) {
     return List(Sym(field.mutable ? "mutable" : "immutable"), field.name);
   });
   rtd_fields.is_vector = true; //tell List not to convert
-  var rtd_def = [Sym("make-record-type-descriptor"),
-                  [Sym("quote"), record_name], parent_rtd, uid,
-                  sealed, opaque, rtd_fields];
-  var cd_def = [Sym("make-record-constructor-descriptor"),
-                  Sym("__rtd"), parent_cd, protocol];
-  var registration =
-    [Sym("let*"), [[Sym("__rtd"), rtd_def],
-                  [Sym("__cd"), cd_def]],
-      [Sym("_define-record-type"),
-        [Sym("quote"), record_name], Sym("__rtd"), Sym("__cd")]];
+  var rtd_def = [
+    Sym("make-record-type-descriptor"),
+    [Sym("quote"), record_name],
+    parent_rtd,
+    uid,
+    sealed,
+    opaque,
+    rtd_fields,
+  ];
+  var cd_def = [
+    Sym("make-record-constructor-descriptor"),
+    Sym("__rtd"),
+    parent_cd,
+    protocol,
+  ];
+  var registration = [
+    Sym("let*"),
+    [
+      [Sym("__rtd"), rtd_def],
+      [Sym("__cd"), cd_def],
+    ],
+    [
+      Sym("_define-record-type"),
+      [Sym("quote"), record_name],
+      Sym("__rtd"),
+      Sym("__cd"),
+    ],
+  ];
 
   // accessors and mutators
-  var accessor_defs = _.map(fields, function(field){
-    var name = field.accessor_name ||
-                 Sym(record_name.name+"-"+field.name.name);
+  var accessor_defs = _.map(fields, function (field) {
+    var name =
+      field.accessor_name || Sym(record_name.name + "-" + field.name.name);
 
     return [Sym("define"), name, [Sym("record-accessor"), rtd, field.idx]];
   });
 
-  var mutator_defs = _.filter(fields, function(field){
+  var mutator_defs = _.filter(fields, function (field) {
     return field.mutable;
   });
-  mutator_defs = _.map(mutator_defs, function(field){
-    var name = field.mutator_name ||
-                 Sym(record_name.name+"-"+field.name.name+"-set!");
+  mutator_defs = _.map(mutator_defs, function (field) {
+    var name =
+      field.mutator_name ||
+      Sym(record_name.name + "-" + field.name.name + "-set!");
 
     return [Sym("define"), name, [Sym("record-mutator"), rtd, field.idx]];
   });
@@ -2181,16 +2546,18 @@ define_syntax("define-record-type", function(x){
   //       (record-mutator (record-type-descriptor square) 1)))
   //
   return deep_array_to_list(
-    [Sym("begin"),
+    [
+      Sym("begin"),
       registration,
       [Sym("define"), constructor_name, [Sym("record-constructor"), cd]],
       [Sym("define"), predicate_name, [Sym("record-predicate"), rtd]],
-      ].concat(accessor_defs).
-        concat(mutator_defs)
+    ]
+      .concat(accessor_defs)
+      .concat(mutator_defs)
   );
 });
 
-define_libfunc("_define-record-type", 3, 3, function(ar){
+define_libfunc("_define-record-type", 3, 3, function (ar) {
   assert_symbol(ar[0]);
   assert_record_td(ar[1]);
   assert_record_cd(ar[2]);
@@ -2199,43 +2566,55 @@ define_libfunc("_define-record-type", 3, 3, function(ar){
 });
 
 //(record-type-descriptor <record name>)    syntax
-define_syntax("record-type-descriptor", function(x){
-  return deep_array_to_list([Sym("_record-type-descriptor"), [Sym("quote"), x.cdr.car]]);
+define_syntax("record-type-descriptor", function (x) {
+  return deep_array_to_list([
+    Sym("_record-type-descriptor"),
+    [Sym("quote"), x.cdr.car],
+  ]);
 });
-define_libfunc("_record-type-descriptor", 1, 1, function(ar){
+define_libfunc("_record-type-descriptor", 1, 1, function (ar) {
   assert_symbol(ar[0]);
   var type = Record.get_type(ar[0].name);
-  if(type)
-    return type.rtd;
+  if (type) return type.rtd;
   else
-    throw new BiwaError("record-type-descriptor: unknown record type "+ar[0].name);
+    throw new BiwaError(
+      "record-type-descriptor: unknown record type " + ar[0].name
+    );
 });
 
 //(record-constructor-descriptor <record name>)    syntax
-define_syntax("record-constructor-descriptor", function(x){
-  return deep_array_to_list([Sym("_record-constructor-descriptor"), [Sym("quote"), x.cdr.car]]);
+define_syntax("record-constructor-descriptor", function (x) {
+  return deep_array_to_list([
+    Sym("_record-constructor-descriptor"),
+    [Sym("quote"), x.cdr.car],
+  ]);
 });
-define_libfunc("_record-constructor-descriptor", 1, 1, function(ar){
+define_libfunc("_record-constructor-descriptor", 1, 1, function (ar) {
   assert_symbol(ar[0]);
   var type = Record.get_type(ar[0].name);
-  if(type)
-    return type.cd;
+  if (type) return type.cd;
   else
-    throw new BiwaError("record-constructor-descriptor: unknown record type "+ar[0].name);
+    throw new BiwaError(
+      "record-constructor-descriptor: unknown record type " + ar[0].name
+    );
 });
 
 // 6.3  Records: Procedural layer
 //(make-record-type-descriptor name    procedure
-define_libfunc("make-record-type-descriptor", 6, 6, function(ar){
-  var name = ar[0], parent_rtd = ar[1], uid = ar[2],
-      sealed = ar[3], opaque = ar[4], fields = ar[5];
+define_libfunc("make-record-type-descriptor", 6, 6, function (ar) {
+  var name = ar[0],
+    parent_rtd = ar[1],
+    uid = ar[2],
+    sealed = ar[3],
+    opaque = ar[4],
+    fields = ar[5];
 
   assert_symbol(name);
-  if(parent_rtd) assert_record_td(parent_rtd);
-  if(uid){
+  if (parent_rtd) assert_record_td(parent_rtd);
+  if (uid) {
     assert_symbol(uid);
     var _rtd = Record.RTD.NongenerativeRecords[uid.name];
-    if(_rtd){
+    if (_rtd) {
       // the record type is already defined.
       return _rtd;
       // should check equality of other arguments..
@@ -2244,39 +2623,39 @@ define_libfunc("make-record-type-descriptor", 6, 6, function(ar){
   sealed = !!sealed;
   opaque = !!opaque;
   assert_vector(fields);
-  for(var i=0; i<fields.length; i++){
+  for (var i = 0; i < fields.length; i++) {
     var list = fields[i];
     assert_symbol(list.car, "mutability");
     assert_symbol(list.cdr.car, "field name");
-    fields[i] = [list.cdr.car.name, (list.car == Sym("mutable"))];
-  };
+    fields[i] = [list.cdr.car.name, list.car == Sym("mutable")];
+  }
 
-  var rtd = new Record.RTD(name, parent_rtd, uid,
-                                   sealed, opaque, fields);
-  if(uid)
-    Record.RTD.NongenerativeRecords[uid.name] = rtd;
+  var rtd = new Record.RTD(name, parent_rtd, uid, sealed, opaque, fields);
+  if (uid) Record.RTD.NongenerativeRecords[uid.name] = rtd;
 
   return rtd;
 });
 
 //(record-type-descriptor? obj)    procedure
-define_libfunc("record-type-descriptor?", 1, 1, function(ar){
-  return (ar[0] instanceof Record.RTD);
+define_libfunc("record-type-descriptor?", 1, 1, function (ar) {
+  return ar[0] instanceof Record.RTD;
 });
 
 //(make-record-constructor-descriptor rtd    procedure
-define_libfunc("make-record-constructor-descriptor", 3, 3, function(ar){
-  var rtd = ar[0], parent_cd = ar[1], protocol = ar[2];
+define_libfunc("make-record-constructor-descriptor", 3, 3, function (ar) {
+  var rtd = ar[0],
+    parent_cd = ar[1],
+    protocol = ar[2];
 
   assert_record_td(rtd);
-  if(parent_cd) assert_record_cd(parent_cd);
-  if(protocol) assert_procedure(protocol);
+  if (parent_cd) assert_record_cd(parent_cd);
+  if (protocol) assert_procedure(protocol);
 
   return new Record.CD(rtd, parent_cd, protocol);
 });
 
 //(record-constructor constructor-descriptor)    procedure
-define_libfunc("record-constructor", 1, 1, function(ar){
+define_libfunc("record-constructor", 1, 1, function (ar) {
   var cd = ar[0];
   assert_record_cd(cd);
 
@@ -2284,36 +2663,41 @@ define_libfunc("record-constructor", 1, 1, function(ar){
 });
 
 //(record-predicate rtd)    procedure
-define_libfunc("record-predicate", 1, 1, function(ar){
+define_libfunc("record-predicate", 1, 1, function (ar) {
   var rtd = ar[0];
   assert_record_td(rtd);
 
-  return function(args){
+  return function (args) {
     var obj = args[0];
 
-    return (obj instanceof Record) &&
-           (obj.rtd === rtd);
+    return obj instanceof Record && obj.rtd === rtd;
   };
 });
 
 //(record-accessor rtd k)    procedure
-define_libfunc("record-accessor", 2, 2, function(ar){
-  var rtd = ar[0], k = ar[1];
+define_libfunc("record-accessor", 2, 2, function (ar) {
+  var rtd = ar[0],
+    k = ar[1];
   assert_record_td(rtd);
   assert_integer(k);
-  for(var _rtd = rtd.parent_rtd; _rtd; _rtd = _rtd.parent_rtd)
+  for (var _rtd = rtd.parent_rtd; _rtd; _rtd = _rtd.parent_rtd)
     k += _rtd.fields.length;
 
-  return function(args){
+  return function (args) {
     var record = args[0];
-    var error_msg = rtd.name.name+"-"+rtd.field_name(k)+": "+
-                    to_write(record)+
-                    " is not a "+rtd.name.name;
+    var error_msg =
+      rtd.name.name +
+      "-" +
+      rtd.field_name(k) +
+      ": " +
+      to_write(record) +
+      " is not a " +
+      rtd.name.name;
     assert(isRecord(record), error_msg);
 
     var descendant = false;
-    for(var _rtd = record.rtd; _rtd; _rtd = _rtd.parent_rtd){
-      if(_rtd == rtd) descendant = true;
+    for (var _rtd = record.rtd; _rtd; _rtd = _rtd.parent_rtd) {
+      if (_rtd == rtd) descendant = true;
     }
     assert(descendant, error_msg);
 
@@ -2322,23 +2706,28 @@ define_libfunc("record-accessor", 2, 2, function(ar){
 });
 
 //(record-mutator rtd k)    procedure
-define_libfunc("record-mutator", 2, 2, function(ar){
-  var rtd = ar[0], k = ar[1];
+define_libfunc("record-mutator", 2, 2, function (ar) {
+  var rtd = ar[0],
+    k = ar[1];
   assert_record_td(rtd);
   assert_integer(k);
-  for(var _rtd = rtd.parent_rtd; _rtd; _rtd = _rtd.parent_rtd)
+  for (var _rtd = rtd.parent_rtd; _rtd; _rtd = _rtd.parent_rtd)
     k += _rtd.fields.length;
 
-  return function(args){
-    var record = args[0], val = args[1];
+  return function (args) {
+    var record = args[0],
+      val = args[1];
     var func_name = rtd.field_name(k);
 
     assert_record(record);
-    assert(record.rtd === rtd,
-          func_name+": "+to_write(record)+
-          " is not a "+rtd.name.name);
-    assert(!record.rtd.sealed,
-          func_name+": "+rtd.name.name+" is sealed (can't mutate)");
+    assert(
+      record.rtd === rtd,
+      func_name + ": " + to_write(record) + " is not a " + rtd.name.name
+    );
+    assert(
+      !record.rtd.sealed,
+      func_name + ": " + rtd.name.name + " is sealed (can't mutate)"
+    );
 
     record.set(k, val);
   };
@@ -2346,73 +2735,73 @@ define_libfunc("record-mutator", 2, 2, function(ar){
 
 // 6.4  Records: Inspection
 //(record? obj)    procedure
-define_libfunc("record?", 1, 1, function(ar){
+define_libfunc("record?", 1, 1, function (ar) {
   var obj = ar[0];
-  if(isRecord(obj)){
-    if(obj.rtd.opaque)
-      return false; // opaque records pretend as if it is not a record.
-    else
-      return true;
-  }
-  else
-    return false;
+  if (isRecord(obj)) {
+    if (obj.rtd.opaque) return false;
+    // opaque records pretend as if it is not a record.
+    else return true;
+  } else return false;
 });
 
 //(record-rtd record)    procedure
-define_libfunc("record-rtd", 1, 1, function(ar){
+define_libfunc("record-rtd", 1, 1, function (ar) {
   assert_record(ar[0]);
   return ar[0].rtd;
 });
 
 //(record-type-name rtd)    procedure
-define_libfunc("record-type-name", 1, 1, function(ar){
+define_libfunc("record-type-name", 1, 1, function (ar) {
   assert_record_td(ar[0]);
   return ar[0].name;
 });
 
 //(record-type-parent rtd)    procedure
-define_libfunc("record-type-parent", 1, 1, function(ar){
+define_libfunc("record-type-parent", 1, 1, function (ar) {
   assert_record_td(ar[0]);
   return ar[0].parent_rtd;
 });
 
 //(record-type-uid rtd)    procedure
-define_libfunc("record-type-uid", 1, 1, function(ar){
+define_libfunc("record-type-uid", 1, 1, function (ar) {
   assert_record_td(ar[0]);
   return ar[0].uid;
 });
 
 //(record-type-generative? rtd)    procedure
-define_libfunc("record-type-generative?", 1, 1, function(ar){
+define_libfunc("record-type-generative?", 1, 1, function (ar) {
   assert_record_td(ar[0]);
   return ar[0].generative;
 });
 
 //(record-type-sealed? rtd)    procedure
-define_libfunc("record-type-sealed?", 1, 1, function(ar){
+define_libfunc("record-type-sealed?", 1, 1, function (ar) {
   assert_record_td(ar[0]);
   return ar[0].sealed;
 });
 
 //(record-type-opaque? rtd)    procedure
-define_libfunc("record-type-opaque?", 1, 1, function(ar){
+define_libfunc("record-type-opaque?", 1, 1, function (ar) {
   assert_record_td(ar[0]);
   return ar[0].opaque;
 });
 
 //(record-type-field-names rtd)    procedure
-define_libfunc("record-type-field-names", 1, 1, function(ar){
+define_libfunc("record-type-field-names", 1, 1, function (ar) {
   assert_record_td(ar[0]);
-  return _.map(ar[0].fields, function(field){ return field.name; });
+  return _.map(ar[0].fields, function (field) {
+    return field.name;
+  });
 });
 
 //(record-field-mutable? rtd k)    procedure
-define_libfunc("record-field-mutable?", 2, 2, function(ar){
-  var rtd = ar[0], k = ar[1];
+define_libfunc("record-field-mutable?", 2, 2, function (ar) {
+  var rtd = ar[0],
+    k = ar[1];
   assert_record_td(ar[0]);
   assert_integer(k);
 
-  for(var _rtd = rtd.parent_rtd; _rtd; _rtd = _rtd.parent_rtd)
+  for (var _rtd = rtd.parent_rtd; _rtd; _rtd = _rtd.parent_rtd)
     k += _rtd.fields.length;
 
   return ar[0].fields[k].mutable;
@@ -2424,7 +2813,7 @@ define_libfunc("record-field-mutable?", 2, 2, function(ar){
 //(with-exception-handler handler thunk)    procedure
 //(guard (<variable>    syntax
 //(raise obj)    procedure
-define_libfunc("raise", 1, 1, function(ar){
+define_libfunc("raise", 1, 1, function (ar) {
   throw new UserError(to_write(ar[0]));
 });
 //(raise-continuable obj)    procedure
@@ -2501,35 +2890,36 @@ define_libfunc("raise", 1, 1, function(ar){
 //-> 8.3 (eof-object? obj)    procedure
 
 //            8.2.6  Input and output ports
-define_libfunc("port?", 1, 1, function(ar){
-  return (ar[0] instanceof Port);
-})
+define_libfunc("port?", 1, 1, function (ar) {
+  return ar[0] instanceof Port;
+});
 //(port-transcoder port)    procedure
-define_libfunc("textual-port?", 1, 1, function(ar){
+define_libfunc("textual-port?", 1, 1, function (ar) {
   assert_port(ar[0]);
   return !ar[0].is_binary;
-})
-define_libfunc("binary-port?", 1, 1, function(ar){
+});
+define_libfunc("binary-port?", 1, 1, function (ar) {
   assert_port(ar[0]);
   return ar[0].is_binary;
-})
+});
 //(transcoded-port binary-port transcoder)    procedure
 //(port-has-port-position? port)    procedure
 //(port-position port)    procedure
 //(port-has-set-port-position!? port)    procedure
 //(set-port-position! port pos)    procedure
-define_libfunc("close-port", 1, 1, function(ar){
+define_libfunc("close-port", 1, 1, function (ar) {
   assert_port(ar[0]);
   ar[0].close();
   return undef;
-})
+});
 //(call-with-port port proc)    procedure
-define_libfunc("call-with-port", 2, 2, function(ar){
-  var port = ar[0], proc = ar[1];
+define_libfunc("call-with-port", 2, 2, function (ar) {
+  var port = ar[0],
+    proc = ar[1];
   assert_port(port);
   assert_closure(proc);
 
-  return new Call(proc, [port], function(ar){
+  return new Call(proc, [port], function (ar) {
     // Automatically close the port
     port.close();
     return ar[0]; // TODO: values
@@ -2573,13 +2963,13 @@ define_libfunc("call-with-port", 2, 2, function(ar){
 //(call-with-bytevector-output-port proc)    procedure
 //(open-string-output-port)    procedure
 //(call-with-string-output-port proc)    procedure
-define_libfunc("call-with-string-output-port", 1, 1, function(ar){
+define_libfunc("call-with-string-output-port", 1, 1, function (ar) {
   var proc = ar[0];
   assert_procedure(proc);
 
   var port = new Port.StringOutput();
 
-  return new Call(proc, [port], function(ar){
+  return new Call(proc, [port], function (ar) {
     port.close();
     return port.output_string();
   });
@@ -2605,23 +2995,23 @@ define_libfunc("call-with-string-output-port", 1, 1, function(ar){
 //(put-bytevector binary-output-port bytevector)    procedure
 //
 //            8.2.12  Textual output
-define_libfunc("put-char", 2, 2, function(ar){
+define_libfunc("put-char", 2, 2, function (ar) {
   assert_port(ar[0]);
   assert_char(ar[1]);
   ar[0].put_string(ar[1].value);
   return undef;
-})
-define_libfunc("put-string", 2, 2, function(ar){
+});
+define_libfunc("put-string", 2, 2, function (ar) {
   assert_port(ar[0]);
   assert_string(ar[1]);
   ar[0].put_string(ar[1]);
   return undef;
-})
-define_libfunc("put-datum", 2, 2, function(ar){
+});
+define_libfunc("put-datum", 2, 2, function (ar) {
   assert_port(ar[0]);
   ar[0].put_string(to_write(ar[1]));
   return undef;
-})
+});
 //
 //  //            8.2.13  Input/output ports
 //(open-file-input/output-port filename)    procedure
@@ -2629,89 +3019,89 @@ define_libfunc("put-datum", 2, 2, function(ar){
 //(make-custom-textual-input/output-port    procedure
 //
 //  //        8.3  Simple I/O
-define_libfunc("eof-object", 0, 0, function(ar){
+define_libfunc("eof-object", 0, 0, function (ar) {
   return eof;
-})
-define_libfunc("eof-object?", 1, 1, function(ar){
+});
+define_libfunc("eof-object?", 1, 1, function (ar) {
   return ar[0] === eof;
-})
+});
 //(call-with-input-file filename proc)    procedure
 //(call-with-output-file filename proc)    procedure
-define_libfunc("input-port?", 1, 1, function(ar){
+define_libfunc("input-port?", 1, 1, function (ar) {
   assert_port(ar[0]);
   return ar[0].is_input;
-})
-define_libfunc("output-port?", 1, 1, function(ar){
+});
+define_libfunc("output-port?", 1, 1, function (ar) {
   assert_port(ar[0]);
   return ar[0].is_output;
-})
-define_libfunc("current-input-port", 0, 0, function(ar){
+});
+define_libfunc("current-input-port", 0, 0, function (ar) {
   return Port.current_input;
-})
-define_libfunc("current-output-port", 0, 0, function(ar){
+});
+define_libfunc("current-output-port", 0, 0, function (ar) {
   return Port.current_output;
-})
-define_libfunc("current-error-port", 0, 0, function(ar){
+});
+define_libfunc("current-error-port", 0, 0, function (ar) {
   return Port.current_error;
-})
+});
 //(with-input-from-file filename thunk)    procedure
 //(with-output-to-file filename thunk)    procedure
 //(open-input-file filename)    procedure
 //(open-output-file filename)    procedure
-define_libfunc("close-input-port", 1, 1, function(ar){
+define_libfunc("close-input-port", 1, 1, function (ar) {
   assert_port(ar[0]);
-  if(!ar[0].is_input)
+  if (!ar[0].is_input)
     throw new BiwaError("close-input-port: port is not input port");
   ar[0].close();
   return undef;
 });
-define_libfunc("close-output-port", 1, 1, function(ar){
+define_libfunc("close-output-port", 1, 1, function (ar) {
   assert_port(ar[0]);
-  if(!ar[0].is_output)
+  if (!ar[0].is_output)
     throw new BiwaError("close-output-port: port is not output port");
   ar[0].close();
   return undef;
 });
 //(read-char)    procedure
 //(peek-char)    procedure
-define_libfunc("read", 0, 1, function(ar){
+define_libfunc("read", 0, 1, function (ar) {
   var port = ar[0] || Port.current_input;
   assert_port(port);
 
-  return port.get_string(function(str){
-    return Interpreter.read(str); 
+  return port.get_string(function (str) {
+    return Interpreter.read(str);
   });
-})
+});
 
-define_libfunc("write-char", 1, 2, function(ar){
+define_libfunc("write-char", 1, 2, function (ar) {
   var port = ar[1] || Port.current_output;
   assert_char(ar[0]);
   port.put_string(ar[0].value);
   return undef;
 });
-define_libfunc("newline", 0, 1, function(ar){
+define_libfunc("newline", 0, 1, function (ar) {
   var port = ar[0] || Port.current_output;
   port.put_string("\n");
   return undef;
 });
-define_libfunc("display", 1, 2, function(ar){
+define_libfunc("display", 1, 2, function (ar) {
   var port = ar[1] || Port.current_output;
   port.put_string(to_display(ar[0]));
   return undef;
 });
-define_libfunc("write", 1, 2, function(ar){
+define_libfunc("write", 1, 2, function (ar) {
   var port = ar[1] || Port.current_output;
   assert_port(port);
   port.put_string(to_write(ar[0]));
   return undef;
 });
-define_libfunc("write-shared", 1, 2, function(ar){
+define_libfunc("write-shared", 1, 2, function (ar) {
   var port = ar[1] || Port.current_output;
   assert_port(port);
   port.put_string(write_shared(ar[0]));
   return undef;
 });
-define_libfunc("write-simple", 1, 2, function(ar){
+define_libfunc("write-simple", 1, 2, function (ar) {
   var port = ar[1] || Port.current_output;
   assert_port(port);
   port.put_string(write_simple(ar[0]));
@@ -2831,42 +3221,50 @@ define_libfunc("write-simple", 1, 2, function(ar){
 
 ////        11.4  Exact bitwise arithmetic
 //(bitwise-not ei)    procedure
-define_libfunc("bitwise-not", 1, 1, function(ar){
-  return ~(ar[0]);
+define_libfunc("bitwise-not", 1, 1, function (ar) {
+  return ~ar[0];
 });
 
 //(bitwise-and ei1 ...)    procedure
-define_libfunc("bitwise-and", 1, null, function(ar){
-  return _.reduce(ar, function(ret, item){ return ret & item; });
+define_libfunc("bitwise-and", 1, null, function (ar) {
+  return _.reduce(ar, function (ret, item) {
+    return ret & item;
+  });
 });
 
 //(bitwise-ior ei1 ...)    procedure
-define_libfunc("bitwise-ior", 1, null, function(ar){
-  return _.reduce(ar, function(ret, item){ return ret | item; });
+define_libfunc("bitwise-ior", 1, null, function (ar) {
+  return _.reduce(ar, function (ret, item) {
+    return ret | item;
+  });
 });
 
 //(bitwise-xor ei1 ...)    procedure
-define_libfunc("bitwise-xor", 1, null, function(ar){
-  return _.reduce(ar, function(ret, item){ return ret ^ item; });
+define_libfunc("bitwise-xor", 1, null, function (ar) {
+  return _.reduce(ar, function (ret, item) {
+    return ret ^ item;
+  });
 });
 
 //(bitwise-if ei1 ei2 ei3)    procedure
-define_libfunc("bitwise-if", 3, 3, function(ar){
+define_libfunc("bitwise-if", 3, 3, function (ar) {
   return (ar[0] & ar[1]) | (~ar[0] & ar[2]);
 });
 
 //(bitwise-bit-count ei)    procedure
-define_libfunc("bitwise-bit-count", 1, 1, function(ar){
-  var e = Math.abs(ar[0]), ret = 0;
+define_libfunc("bitwise-bit-count", 1, 1, function (ar) {
+  var e = Math.abs(ar[0]),
+    ret = 0;
   for (; e != 0; e >>= 1) {
-    if(e & 1) ret++;
+    if (e & 1) ret++;
   }
   return ret;
 });
 
 //(bitwise-length ei)    procedure
-define_libfunc("bitwise-length", 1, 1, function(ar){
-  var e = Math.abs(ar[0]), ret = 0;
+define_libfunc("bitwise-length", 1, 1, function (ar) {
+  var e = Math.abs(ar[0]),
+    ret = 0;
   for (; e != 0; e >>= 1) {
     ret++;
   }
@@ -2874,8 +3272,9 @@ define_libfunc("bitwise-length", 1, 1, function(ar){
 });
 
 //(bitwise-first-bit-set ei)    procedure
-define_libfunc("bitwise-first-bit-set", 1, 1, function(ar){
-  var e = Math.abs(ar[0]), ret = 0;
+define_libfunc("bitwise-first-bit-set", 1, 1, function (ar) {
+  var e = Math.abs(ar[0]),
+    ret = 0;
   if (e == 0) return -1;
   for (; e != 0; e >>= 1) {
     if (e & 1) return ret;
@@ -2884,71 +3283,80 @@ define_libfunc("bitwise-first-bit-set", 1, 1, function(ar){
 });
 
 //(bitwise-bit-set? ei1 ei2)    procedure
-define_libfunc("bitwise-bit-set?", 2, 2, function(ar){
+define_libfunc("bitwise-bit-set?", 2, 2, function (ar) {
   return !!(ar[0] & (1 << ar[1]));
 });
 
 //(bitwise-copy-bit ei1 n b)    procedure
-define_libfunc("bitwise-copy-bit", 3, 3, function(ar){
-  var mask = (1 << ar[1]);
-  return (mask & (ar[2] << ar[1])) |   // Set n-th bit to b
-         (~mask & ar[0]);              // and use ei1 for rest of the bits
+define_libfunc("bitwise-copy-bit", 3, 3, function (ar) {
+  var mask = 1 << ar[1];
+  return (
+    (mask & (ar[2] << ar[1])) | // Set n-th bit to b
+    (~mask & ar[0])
+  ); // and use ei1 for rest of the bits
 });
 
 //(bitwise-bit-field ei1 start end)    procedure
-define_libfunc("bitwise-bit-field", 3, 3, function(ar){
-  var mask = ~(-1 << ar[2]);  // Has 1 at 0...end
+define_libfunc("bitwise-bit-field", 3, 3, function (ar) {
+  var mask = ~(-1 << ar[2]); // Has 1 at 0...end
   return (mask & ar[0]) >> ar[1];
 });
 
 //(bitwise-copy-bit-field dst start end src)    procedure
-define_libfunc("bitwise-copy-bit-field", 4, 4, function(ar){
-  var dst=ar[0], start=ar[1], end=ar[2], src=ar[3];
-  var mask = ~(-1 << end) &   // Has 1 at 0...end
-              (-1 << start)   // Clear 0...start
-  return (mask & (src << start)) |
-         (~mask & dst);
+define_libfunc("bitwise-copy-bit-field", 4, 4, function (ar) {
+  var dst = ar[0],
+    start = ar[1],
+    end = ar[2],
+    src = ar[3];
+  var mask =
+    ~(-1 << end) & // Has 1 at 0...end
+    (-1 << start); // Clear 0...start
+  return (mask & (src << start)) | (~mask & dst);
 });
 
 //(bitwise-arithmetic-shift ei1 ei2)    procedure
-define_libfunc("bitwise-arithmetic-shift", 2, 2, function(ar){
-  return (ar[1] >= 0) ? (ar[0] << ar[1]) : (ar[0] >> -ar[1]);
+define_libfunc("bitwise-arithmetic-shift", 2, 2, function (ar) {
+  return ar[1] >= 0 ? ar[0] << ar[1] : ar[0] >> -ar[1];
 });
 
 //(bitwise-arithmetic-shift-left ei1 ei2)    procedure
-define_libfunc("bitwise-arithmetic-shift-left", 2, 2, function(ar){
+define_libfunc("bitwise-arithmetic-shift-left", 2, 2, function (ar) {
   return ar[0] << ar[1];
 });
 
 //(bitwise-arithmetic-shift-right ei1 ei2)    procedure
-define_libfunc("bitwise-arithmetic-shift-right", 2, 2, function(ar){
+define_libfunc("bitwise-arithmetic-shift-right", 2, 2, function (ar) {
   return ar[0] >> ar[1];
 });
 
 //(bitwise-rotate-bit-field ei1 start end count)    procedure
-define_libfunc("bitwise-rotate-bit-field", 4, 4, function(ar){
-  var n=ar[0], start=ar[1], end=ar[2], count=ar[3];
+define_libfunc("bitwise-rotate-bit-field", 4, 4, function (ar) {
+  var n = ar[0],
+    start = ar[1],
+    end = ar[2],
+    count = ar[3];
   var width = end - start;
   if (width <= 0) return n;
 
   count %= width;
   var orig_field = (~(-1 << end) & n) >> start;
-  var rotated_field = (orig_field << count) |
-                      (orig_field >> (width - count))
+  var rotated_field = (orig_field << count) | (orig_field >> (width - count));
 
   var mask = ~(-1 << end) & (-1 << start);
-  return (mask & (rotated_field << start)) |
-         (~mask & n);
+  return (mask & (rotated_field << start)) | (~mask & n);
 });
 
 //(bitwise-reverse-bit-field ei1 ei2 ei3)    procedure
-define_libfunc("bitwise-reverse-bit-field", 3, 3, function(ar){
-  var ret=ar[0], n=ar[0], start=ar[1], end=ar[2];
-  var orig_field = ((~(-1 << end) & n) >> start);
-  for (var i=0; i<(end-start); i++, orig_field>>=1) {
+define_libfunc("bitwise-reverse-bit-field", 3, 3, function (ar) {
+  var ret = ar[0],
+    n = ar[0],
+    start = ar[1],
+    end = ar[2];
+  var orig_field = (~(-1 << end) & n) >> start;
+  for (var i = 0; i < end - start; i++, orig_field >>= 1) {
     var bit = orig_field & 1;
     var setpos = end - 1 - i;
-    var mask = (1 << setpos);
+    var mask = 1 << setpos;
     ret = (mask & (bit << setpos)) | (~mask & ret);
   }
   return ret;
@@ -2965,18 +3373,18 @@ define_libfunc("bitwise-reverse-bit-field", 3, 3, function(ar){
 //13.1  Constructors
 //(define h (make-eq-hashtale)
 //(define h (make-eq-hashtable 1000))
-define_libfunc("make-eq-hashtable", 0, 1, function(ar){
+define_libfunc("make-eq-hashtable", 0, 1, function (ar) {
   // Note: ar[1] (hashtable size) is just ignored
   return new Hashtable(Hashtable.eq_hash, Hashtable.eq_equiv);
 });
 //(make-eqv-hashtable)    procedure
 //(make-eqv-hashtable k)    procedure
-define_libfunc("make-eqv-hashtable", 0, 1, function(ar){
+define_libfunc("make-eqv-hashtable", 0, 1, function (ar) {
   return new Hashtable(Hashtable.eqv_hash, Hashtable.eqv_equiv);
 });
 //(make-hashtable hash-function equiv)    procedure
 //(make-hashtable hash-function equiv k)    procedure
-define_libfunc("make-hashtable", 2, 3, function(ar){
+define_libfunc("make-hashtable", 2, 3, function (ar) {
   assert_procedure(ar[0]);
   assert_procedure(ar[1]);
   return new Hashtable(ar[0], ar[1]);
@@ -2984,11 +3392,11 @@ define_libfunc("make-hashtable", 2, 3, function(ar){
 
 //13.2  Procedures
 // (hashtable? hash)
-define_libfunc("hashtable?", 1, 1, function(ar){
+define_libfunc("hashtable?", 1, 1, function (ar) {
   return ar[0] instanceof Hashtable;
 });
 //(hashtable-size hash)
-define_libfunc("hashtable-size", 1, 1, function(ar){
+define_libfunc("hashtable-size", 1, 1, function (ar) {
   assert_hashtable(ar[0]);
   return ar[0].keys().length;
 });
@@ -3005,147 +3413,159 @@ define_libfunc("hashtable-size", 1, 1, function(ar){
 //               hashed - Object hashed
 //
 // Returns an instance of BiwaScheme.Call.
-const find_hash_pair = function(hash, key, callbacks){
+const find_hash_pair = function (hash, key, callbacks) {
   // invoke hash proc
-  return new Call(hash.hash_proc, [key], function(ar){
+  return new Call(hash.hash_proc, [key], function (ar) {
     var hashed = ar[0];
     var candidate_pairs = hash.candidate_pairs(hashed);
 
-    if (!candidate_pairs){ // shortcut: obviously not found
+    if (!candidate_pairs) {
+      // shortcut: obviously not found
       return callbacks.on_not_found(hashed);
     }
 
     // search the exact key from candidates
     return Call.foreach(candidate_pairs, {
-      call: function(pair){
+      call: function (pair) {
         // invoke the equivalence proc
         return new Call(hash.equiv_proc, [key, pair[0]]);
       },
-      result: function(equal, pair){
-        if(equal) {       // found
+      result: function (equal, pair) {
+        if (equal) {
+          // found
           return callbacks.on_found(pair, hashed);
         }
       },
-      finish: function(){ // not found
+      finish: function () {
+        // not found
         return callbacks.on_not_found(hashed);
-      }
+      },
     });
   });
 };
 
 //(hashtable-ref hash "foo" #f)
-define_libfunc("hashtable-ref", 3, 3, function(ar){
-  var hash = ar[0], key = ar[1], ifnone = ar[2];
+define_libfunc("hashtable-ref", 3, 3, function (ar) {
+  var hash = ar[0],
+    key = ar[1],
+    ifnone = ar[2];
   assert_hashtable(hash);
 
   return find_hash_pair(hash, key, {
-    on_found: function(pair){
+    on_found: function (pair) {
       return pair[1];
     },
-    on_not_found: function(hashed){
+    on_not_found: function (hashed) {
       return ifnone;
-    }
+    },
   });
 });
 
 //(hashtable-set! hash "foo" '(1 2))
-define_libfunc("hashtable-set!", 3, 3, function(ar){
-  var hash = ar[0], key = ar[1], value = ar[2];
+define_libfunc("hashtable-set!", 3, 3, function (ar) {
+  var hash = ar[0],
+    key = ar[1],
+    value = ar[2];
   assert_hashtable(hash);
   assert(hash.mutable, "hashtable is not mutable");
 
   return find_hash_pair(hash, key, {
-    on_found: function(pair){
+    on_found: function (pair) {
       pair[1] = value;
       return undef;
     },
-    on_not_found: function(hashed){
+    on_not_found: function (hashed) {
       hash.add_pair(hashed, key, value);
       return undef;
-    }
+    },
   });
 });
 
 //(hashtable-delete! hash "foo")
-define_libfunc("hashtable-delete!", 2, 2, function(ar){
-  var hash = ar[0], key = ar[1];
+define_libfunc("hashtable-delete!", 2, 2, function (ar) {
+  var hash = ar[0],
+    key = ar[1];
   assert_hashtable(hash);
   assert(hash.mutable, "hashtable is not mutable");
 
   return find_hash_pair(hash, key, {
-    on_found: function(pair, hashed){
+    on_found: function (pair, hashed) {
       hash.remove_pair(hashed, pair);
       return undef;
     },
-    on_not_found: function(hashed){
+    on_not_found: function (hashed) {
       return undef;
-    }
+    },
   });
 });
 
 //(hashtable-contains? hash "foo")
-define_libfunc("hashtable-contains?", 2, 2, function(ar){
-  var hash = ar[0], key = ar[1];
+define_libfunc("hashtable-contains?", 2, 2, function (ar) {
+  var hash = ar[0],
+    key = ar[1];
   assert_hashtable(hash);
 
   return find_hash_pair(hash, key, {
-    on_found: function(pair){
+    on_found: function (pair) {
       return true;
     },
-    on_not_found: function(hashed){
+    on_not_found: function (hashed) {
       return false;
-    }
+    },
   });
 });
 
 //(hashtable-update! hashtable key proc default)    procedure
-define_libfunc("hashtable-update!", 4, 4, function(ar){
-  var hash = ar[0], key = ar[1], proc = ar[2], ifnone = ar[3];
+define_libfunc("hashtable-update!", 4, 4, function (ar) {
+  var hash = ar[0],
+    key = ar[1],
+    proc = ar[2],
+    ifnone = ar[3];
   assert_hashtable(hash);
   assert(hash.mutable, "hashtable is not mutable");
   assert_procedure(proc);
 
   return find_hash_pair(hash, key, {
-    on_found: function(pair, hashed){
+    on_found: function (pair, hashed) {
       // invoke proc and get new value
-      return new Call(proc, [pair[1]], function(ar){
+      return new Call(proc, [pair[1]], function (ar) {
         // replace the value
         pair[1] = ar[0];
         return undef;
       });
     },
-    on_not_found: function(hashed){
+    on_not_found: function (hashed) {
       // invoke proc and get new value
-      return new Call(proc, [ifnone], function(ar){
+      return new Call(proc, [ifnone], function (ar) {
         // create new pair
         hash.add_pair(hashed, key, ar[0]);
         return undef;
       });
-    }
+    },
   });
 });
 //(hashtable-copy hashtable)    procedure
 //(hashtable-copy hashtable mutable)    procedure
-define_libfunc("hashtable-copy", 1, 2, function(ar){
-  var mutable = (ar[1]===undefined) ? false : !!ar[1];
+define_libfunc("hashtable-copy", 1, 2, function (ar) {
+  var mutable = ar[1] === undefined ? false : !!ar[1];
   assert_hashtable(ar[0]);
   return ar[0].create_copy(mutable);
 });
 //(hashtable-clear! hashtable)    procedure
 //(hashtable-clear! hashtable k)    procedure
-define_libfunc("hashtable-clear!", 0, 1, function(ar){
+define_libfunc("hashtable-clear!", 0, 1, function (ar) {
   assert_hashtable(ar[0]);
   assert(ar[0].mutable, "hashtable is not mutable");
   ar[0].clear();
   return undef;
 });
 //(hashtable-keys hash)  ; => vector
-define_libfunc("hashtable-keys", 1, 1, function(ar){
+define_libfunc("hashtable-keys", 1, 1, function (ar) {
   assert_hashtable(ar[0]);
   return ar[0].keys();
 });
 //(hashtable-entries hash)  ; => two vectors (keys, values)
-define_libfunc("hashtable-entries", 1, 1, function(ar){
+define_libfunc("hashtable-entries", 1, 1, function (ar) {
   assert_hashtable(ar[0]);
   return new Values([ar[0].keys(), ar[0].values()]);
 });
@@ -3153,17 +3573,17 @@ define_libfunc("hashtable-entries", 1, 1, function(ar){
 //13.3  Inspection
 
 //(hashtable-equivalence-function hashtable)    procedure
-define_libfunc("hashtable-equivalence-function", 1, 1, function(ar){
+define_libfunc("hashtable-equivalence-function", 1, 1, function (ar) {
   assert_hashtable(ar[0]);
   return ar[0].equiv_proc;
 });
 //(hashtable-hash-function hashtable)    procedure
-define_libfunc("hashtable-hash-function", 1, 1, function(ar){
+define_libfunc("hashtable-hash-function", 1, 1, function (ar) {
   assert_hashtable(ar[0]);
   return ar[0].hash_proc;
 });
 //(hashtable-mutable? hashtable)    procedure
-define_libfunc("hashtable-mutable?", 1, 1, function(ar){
+define_libfunc("hashtable-mutable?", 1, 1, function (ar) {
   assert_hashtable(ar[0]);
   return ar[0].mutable;
 });
@@ -3171,19 +3591,19 @@ define_libfunc("hashtable-mutable?", 1, 1, function(ar){
 //13.4  Hash functions
 
 //(equal-hash obj)    procedure
-define_libfunc("equal-hash", 0, 0, function(ar){
+define_libfunc("equal-hash", 0, 0, function (ar) {
   return Hashtable.equal_hash;
 });
 //(string-hash string)    procedure
-define_libfunc("string-hash", 0, 0, function(ar){
+define_libfunc("string-hash", 0, 0, function (ar) {
   return Hashtable.string_hash;
 });
 //(string-ci-hash string)    procedure
-define_libfunc("string-ci-hash", 0, 0, function(ar){
+define_libfunc("string-ci-hash", 0, 0, function (ar) {
   return Hashtable.string_ci_hash;
 });
 //(symbol-hash symbol)    procedure
-define_libfunc("symbol-hash", 0, 0, function(ar){
+define_libfunc("symbol-hash", 0, 0, function (ar) {
   return Hashtable.symbol_hash;
 });
 
@@ -3191,7 +3611,7 @@ define_libfunc("symbol-hash", 0, 0, function(ar){
 // Chapter 14 Enumerators
 //
 //(make-enumeration symbol-list) -> enum-set(new type)
-define_libfunc("make-enumeration", 1, 1, function(ar){
+define_libfunc("make-enumeration", 1, 1, function (ar) {
   assert_list(ar[0]);
   var members = ar[0].to_array();
   var enum_type = new Enumeration.EnumType(members);
@@ -3199,81 +3619,84 @@ define_libfunc("make-enumeration", 1, 1, function(ar){
 });
 
 //(enum-set-universe enum-set) -> enum-set(same type as the argument)
-define_libfunc("enum-set-universe", 1, 1, function(ar){
+define_libfunc("enum-set-universe", 1, 1, function (ar) {
   assert_enum_set(ar[0]);
   return ar[0].enum_type.universe();
 });
 
 //(enum-set-indexer enum-set) -> (lambda (sym)) -> integer or #f
-define_libfunc("enum-set-indexer", 1, 1, function(ar){
+define_libfunc("enum-set-indexer", 1, 1, function (ar) {
   assert_enum_set(ar[0]);
   return ar[0].enum_type.indexer();
 });
 
 //(enum-set-constructor enum-set) -> (lambda (syms)) -> enum-set(same type as the argument)
-define_libfunc("enum-set-constructor", 1, 1, function(ar){
+define_libfunc("enum-set-constructor", 1, 1, function (ar) {
   assert_enum_set(ar[0]);
   return ar[0].enum_type.constructor_();
 });
 
 //(enum-set->list enum-set) -> symbol-list
-define_libfunc("enum-set->list", 1, 1, function(ar){
+define_libfunc("enum-set->list", 1, 1, function (ar) {
   assert_enum_set(ar[0]);
   return ar[0].symbol_list();
 });
 
 //(enum-set-member? symbol enum-set) -> bool
-define_libfunc("enum-set-member?", 2, 2, function(ar){
+define_libfunc("enum-set-member?", 2, 2, function (ar) {
   assert_symbol(ar[0]);
   assert_enum_set(ar[1]);
   return ar[1].is_member(ar[0]);
 });
 
 //(enum-set-subset? esa esb) -> bool
-define_libfunc("enum-set-subset?", 2, 2, function(ar){
+define_libfunc("enum-set-subset?", 2, 2, function (ar) {
   assert_enum_set(ar[0]);
   assert_enum_set(ar[1]);
   return ar[0].is_subset(ar[1]);
 });
 
 //(enum-set=? esa esb) -> bool
-define_libfunc("enum-set=?", 2, 2, function(ar){
+define_libfunc("enum-set=?", 2, 2, function (ar) {
   assert_enum_set(ar[0]);
   assert_enum_set(ar[1]);
   return ar[0].equal_to(ar[1]);
 });
 
 //(enum-set-union es1 es2) -> enum-set
-define_libfunc("enum-set-union", 2, 2, function(ar){
+define_libfunc("enum-set-union", 2, 2, function (ar) {
   assert_enum_set(ar[0]);
   assert_enum_set(ar[1]);
-  assert(ar[0].enum_type === ar[1].enum_type,
-         "two enum-sets must be the same enum-type", "enum-set-union");
+  assert(
+    ar[0].enum_type === ar[1].enum_type,
+    "two enum-sets must be the same enum-type",
+    "enum-set-union"
+  );
   return ar[0].union(ar[1]);
 });
 
 //(enum-set-intersection es1 es2) -> enum-set
-define_libfunc("enum-set-intersection", 2, 2, function(ar){
+define_libfunc("enum-set-intersection", 2, 2, function (ar) {
   assert_enum_set(ar[0]);
   assert_enum_set(ar[1]);
   return ar[0].intersection(ar[1]);
 });
 
 //(enum-set-difference es1 es2) -> enum-set
-define_libfunc("enum-set-difference", 2, 2, function(ar){
+define_libfunc("enum-set-difference", 2, 2, function (ar) {
   assert_enum_set(ar[0]);
   assert_enum_set(ar[1]);
   return ar[0].difference(ar[1]);
 });
 
 //(enum-set-complement enum-set) -> enum-set
-define_libfunc("enum-set-complement", 1, 1, function(ar){
+define_libfunc("enum-set-complement", 1, 1, function (ar) {
   assert_enum_set(ar[0]);
   return ar[0].complement();
 });
 
 //(enum-set-projection esa esb) -> enum-set
-define_libfunc("enum-set-projection", 2, 2, function(ar){
+define_libfunc("enum-set-projection", 2, 2, function (ar) {
   assert_enum_set(ar[0]);
   assert_enum_set(ar[1]);
   return ar[0].projection(ar[1]);
@@ -3286,57 +3709,71 @@ define_libfunc("enum-set-projection", 2, 2, function(ar){
 //     - an EnumType
 //     - (color red) ;=> 'red
 //     - (color-set red black) ;=> #<enum-set (red black)>
-define_syntax("define-enumeration", function(x){
+define_syntax("define-enumeration", function (x) {
   // Extract parameters
   var type_name = x.cdr.car;
-  assert(isSymbol(type_name),
-         "expected symbol for type_name", "define-enumeration");
+  assert(
+    isSymbol(type_name),
+    "expected symbol for type_name",
+    "define-enumeration"
+  );
   type_name = type_name.name;
 
   var members = x.cdr.cdr.car;
-  assert(isList(members),
-         "expected list of symbol for members", "define-enumeration");
+  assert(
+    isList(members),
+    "expected list of symbol for members",
+    "define-enumeration"
+  );
   members = members.to_array();
 
   var constructor_name = x.cdr.cdr.cdr.car;
-  assert(isSymbol(constructor_name),
-         "expected symbol for constructor_name", "define-enumeration");
+  assert(
+    isSymbol(constructor_name),
+    "expected symbol for constructor_name",
+    "define-enumeration"
+  );
   constructor_name = constructor_name.name;
 
   // Define EnumType
   var enum_type = new Enumeration.EnumType(members);
 
   // Define (color red)
-  define_syntax(type_name, function(x){
+  define_syntax(type_name, function (x) {
     // (color)
-    assert(!isNil(x.cdr),
-           "an argument is needed", type_name);
+    assert(!isNil(x.cdr), "an argument is needed", type_name);
 
     var arg = x.cdr.car;
     assert_symbol(arg, type_name);
 
     // Check arg is included in the universe
-    assert(_.include(enum_type.members, arg),
-      arg.name+" is not included in the universe: "+
+    assert(
+      _.include(enum_type.members, arg),
+      arg.name +
+        " is not included in the universe: " +
         to_write(enum_type.members),
-      type_name);
+      type_name
+    );
 
     return List(Sym("quote"), arg);
   });
 
   // Define (color-set red black)
-  define_syntax(constructor_name, function(x){
+  define_syntax(constructor_name, function (x) {
     assert_list(x.cdr, constructor_name);
 
     var symbols = x.cdr.to_array();
 
     // Check each argument is included in the universe
-    _.each(symbols, function(arg){
+    symbols.forEach(function (arg) {
       assert_symbol(arg, constructor_name);
-      assert(_.include(enum_type.members, arg),
-        arg.name+" is not included in the universe: "+
+      assert(
+        _.include(enum_type.members, arg),
+        arg.name +
+          " is not included in the universe: " +
           to_write(enum_type.members),
-        constructor_name);
+        constructor_name
+      );
     });
 
     // Create an EnumSet
@@ -3353,7 +3790,7 @@ define_syntax("define-enumeration", function(x){
 // Chapter 16 eval
 //
 //(eval expression environment)    procedure
-define_libfunc("eval", 1, 1, function(ar, intp){
+define_libfunc("eval", 1, 1, function (ar, intp) {
   //TODO: environment
   //TODO: this implementation has a bug that
   //  expressions which contains #<undef>, etc. cannot be evaluated.
@@ -3395,77 +3832,82 @@ define_libfunc("eval", 1, 1, function(ar, intp){
 // R7RS Promise
 //
 // (delay expression)
-define_syntax("delay", function(x){
+define_syntax("delay", function (x) {
   if (x.cdr === nil) {
     throw new BiwaError("malformed delay: no argument");
   }
   if (x.cdr.cdr !== nil) {
-    throw new BiwaError("malformed delay: too many arguments: "+
-                    write_ss(x));
+    throw new BiwaError("malformed delay: too many arguments: " + write_ss(x));
   }
   var expr = x.cdr.car;
   // Expand into call of internal function
   // ( procedure->promise (lambda () (make-promise expr)))
-  return new Pair(Sym(" procedure->promise"),
-           new Pair(new Pair(Sym("lambda"),
-                      new Pair(nil,
-                        new Pair(new Pair(Sym("make-promise"),
-                                   new Pair(expr, nil)),
-                          nil)))));
+  return new Pair(
+    Sym(" procedure->promise"),
+    new Pair(
+      new Pair(
+        Sym("lambda"),
+        new Pair(
+          nil,
+          new Pair(new Pair(Sym("make-promise"), new Pair(expr, nil)), nil)
+        )
+      )
+    )
+  );
 });
 
 // (delay-force promise-expr)
-define_syntax("delay-force", function(x){
+define_syntax("delay-force", function (x) {
   if (x.cdr === nil) {
     throw new BiwaError("malformed delay-force: no argument");
   }
   if (x.cdr.cdr !== nil) {
-    throw new BiwaError("malformed delay-force: too many arguments: "+
-                    write_ss(x));
+    throw new BiwaError(
+      "malformed delay-force: too many arguments: " + write_ss(x)
+    );
   }
   var expr = x.cdr.car;
   // Expand into call of internal function
   // ( procedure->promise (lambda () expr))
-  return new Pair(Sym(" procedure->promise"),
-           new Pair(new Pair(Sym("lambda"),
-                      new Pair(nil,
-                        new Pair(expr, nil))), nil));
+  return new Pair(
+    Sym(" procedure->promise"),
+    new Pair(new Pair(Sym("lambda"), new Pair(nil, new Pair(expr, nil))), nil)
+  );
 });
 
 // (force promise)
-var force = function(promise) {
+var force = function (promise) {
   if (promise.is_done()) {
     return promise.value();
   }
-  return new Call(promise.thunk(), [], function(ar) {
+  return new Call(promise.thunk(), [], function (ar) {
     assert_promise(ar[0]);
     var new_promise = ar[0];
-    if (promise.is_done()) {  // reentrant!
+    if (promise.is_done()) {
+      // reentrant!
       return promise.value();
-    }
-    else {
+    } else {
       promise.update_with(new_promise);
       return force(new_promise);
     }
   });
 };
-define_libfunc("force", 1, 1, function(ar, intp){
+define_libfunc("force", 1, 1, function (ar, intp) {
   assert_promise(ar[0]);
   return force(ar[0]);
 });
 
 // (promise? obj)
-define_libfunc("promise?", 1, 1, function(ar, intp){
-  return (ar[0] instanceof BiwaPromise);
+define_libfunc("promise?", 1, 1, function (ar, intp) {
+  return ar[0] instanceof BiwaPromise;
 });
 
 // (make-promise obj)
-define_libfunc("make-promise", 1, 1, function(ar, intp){
+define_libfunc("make-promise", 1, 1, function (ar, intp) {
   var obj = ar[0];
   if (obj instanceof BiwaPromise) {
     return obj;
-  }
-  else {
+  } else {
     return BiwaPromise.done(obj);
   }
 });
@@ -3473,7 +3915,7 @@ define_libfunc("make-promise", 1, 1, function(ar, intp){
 // internal function
 // ( procedure->promise proc)
 // proc must be a procedure with no argument and return a promise
-define_libfunc(" procedure->promise", 1, 1, function(ar, intp){
+define_libfunc(" procedure->promise", 1, 1, function (ar, intp) {
   assert_procedure(ar[0]);
   return BiwaPromise.fresh(ar[0]);
 });
@@ -3484,25 +3926,25 @@ define_libfunc(" procedure->promise", 1, 1, function(ar, intp){
 
 // (make-parameter init)
 // (make-parameter init converter)
-define_libfunc("make-parameter", 1, 2, function(ar, intp){
+define_libfunc("make-parameter", 1, 2, function (ar, intp) {
   let currentValue;
   const converter = ar[1];
   // A parameter is represented by a JS function.
   // (parameterObj)   ;=> Return the current value
   // (parameterObj v) ;=> Set v as the value and return the original value
-  const parameterObj = function(ar2) {
-    if (ar2.length == 0) { // Get
+  const parameterObj = function (ar2) {
+    if (ar2.length == 0) {
+      // Get
       return currentValue;
-    }
-    else { // Set
+    } else {
+      // Set
       const origValue = currentValue;
       if (converter) {
-        return new Call(converter, [ar2[0]], ar3 => {
+        return new Call(converter, [ar2[0]], (ar3) => {
           currentValue = ar3[0];
           return origValue;
         });
-      }
-      else {
+      } else {
         currentValue = ar2[0];
         return origValue;
       }
@@ -3510,12 +3952,11 @@ define_libfunc("make-parameter", 1, 2, function(ar, intp){
   };
 
   if (converter) {
-    return new Call(converter, [ar[0]], initialValue => {
+    return new Call(converter, [ar[0]], (initialValue) => {
       currentValue = initialValue;
       return parameterObj;
     });
-  }
-  else {
+  } else {
     const initialValue = ar[0];
     currentValue = initialValue;
     return parameterObj;
@@ -3523,7 +3964,7 @@ define_libfunc("make-parameter", 1, 2, function(ar, intp){
 });
 
 // (parameterize ((param val) ...) body ...)
-define_syntax("parameterize", function(x){
+define_syntax("parameterize", function (x) {
   const inits = x.cdr.car.to_array();
   const body = x.cdr.cdr;
   const tmpNames = inits.map(() => gensym());
@@ -3532,19 +3973,26 @@ define_syntax("parameterize", function(x){
   //     (lambda () (begin (set! tmp0 (param0 tmp0))) ...)
   //     (lambda () body ...)
   //     (lambda () (begin (set! tmp0 (param0 tmp0))) ...)))
-  const givenValues = List(...inits.map((item, i) =>
-    List(tmpNames[i], item.cdr.car)
-  ));
-  const updateValues = Cons(Sym("begin"), List(...inits.map((item, i) =>
-    List(Sym("set!"), tmpNames[i], List(item.car, tmpNames[i]))
-  )));
-  
+  const givenValues = List(
+    ...inits.map((item, i) => List(tmpNames[i], item.cdr.car))
+  );
+  const updateValues = Cons(
+    Sym("begin"),
+    List(
+      ...inits.map((item, i) =>
+        List(Sym("set!"), tmpNames[i], List(item.car, tmpNames[i]))
+      )
+    )
+  );
+
   const before = List(Sym("lambda"), nil, updateValues);
-  const thunk = Cons(Sym("lambda"),
-                  Cons(nil, body));
+  const thunk = Cons(Sym("lambda"), Cons(nil, body));
   const after = List(Sym("lambda"), nil, updateValues);
   //return List(Sym("quote"),
-  return List(Sym("let"), givenValues,
-           List(Sym("dynamic-wind"), before, thunk, after))
+  return List(
+    Sym("let"),
+    givenValues,
+    List(Sym("dynamic-wind"), before, thunk, after)
+  );
   //)
 });

--- a/src/platforms/browser/dumper.js
+++ b/src/platforms/browser/dumper.js
@@ -160,7 +160,7 @@ class Dumper {
            "#"+this.n_dumps+"</a></td></tr>";
 
       // registers
-      _.each(_.keys(obj), _.bind(function(key){
+      Object.keys(obj).forEach(_.bind(function(key){
         var value = obj[key];
         if(key!="x" && key != "stack"){
           value = (key=="c" ? this.dump_closure(value)

--- a/src/system/call.js
+++ b/src/system/call.js
@@ -164,7 +164,7 @@ Call.default_callbacks = {
 }
 Call.foreach = function(obj, callbacks, is_multi){
   is_multi || (is_multi = false);
-  _.each(["call", "result", "finish"], function(key){
+  ["call", "result", "finish"].forEach(function(key){
     if(!callbacks[key])
       callbacks[key] = Call.default_callbacks[key];
   })

--- a/src/system/enumeration.js
+++ b/src/system/enumeration.js
@@ -66,7 +66,7 @@ Enumeration.EnumType = class {
     return _.bind(function(ar){
       assert_list(ar[0], "(enum-set constructor)");
       var symbols = ar[0].to_array();
-      _.each(symbols, function(arg){
+      symbols.forEach(function(arg){
         assert_symbol(arg, "(enum-set constructor)");
       });
 

--- a/src/system/escape.js
+++ b/src/system/escape.js
@@ -1,0 +1,49 @@
+// from lodash
+
+/** Used to map characters to HTML entities. */
+const htmlEscapes = {
+  "&": "&amp",
+  "<": "&lt",
+  ">": "&gt",
+  '"': "&quot",
+  "'": "&#39",
+};
+
+/** Used to match HTML entities and HTML characters. */
+const reUnescapedHtml = /[&<>"']/g;
+const reHasUnescapedHtml = RegExp(reUnescapedHtml.source);
+
+/**
+ * Converts the characters "&", "<", ">", '"', and "'" in `string` to their
+ * corresponding HTML entities.
+ *
+ * **Note:** No other characters are escaped. To escape additional
+ * characters use a third-party library like [_he_](https://mths.be/he).
+ *
+ * Though the ">" character is escaped for symmetry, characters like
+ * ">" and "/" don't need escaping in HTML and have no special meaning
+ * unless they're part of a tag or unquoted attribute value. See
+ * [Mathias Bynens's article](https://mathiasbynens.be/notes/ambiguous-ampersands)
+ * (under "semi-related fun fact") for more details.
+ *
+ * When working with HTML you should always
+ * [quote attribute values](http://wonko.com/post/html-escaping) to reduce
+ * XSS vectors.
+ *
+ * @since 0.1.0
+ * @category String
+ * @param {string} [string=''] The string to escape.
+ * @returns {string} Returns the escaped string.
+ * @see escapeRegExp, unescape
+ * @example
+ *
+ * escape('fred, barney, & pebbles')
+ * // => 'fred, barney, &amp pebbles'
+ */
+function escape(string) {
+  return string && reHasUnescapedHtml.test(string)
+    ? string.replace(reUnescapedHtml, (chr) => htmlEscapes[chr])
+    : string;
+}
+
+export default escape;

--- a/src/system/hashtable.js
+++ b/src/system/hashtable.js
@@ -60,7 +60,7 @@ class Hashtable {
     var copy = new Hashtable(this.hash_proc, this.equiv_proc,
                                         mutable);
     // clone the pairs to copy
-    _.each(_.keys(this.pairs_of), _.bind(function(hashed){
+    Object.keys(this.pairs_of).forEach(_.bind(function(hashed){
       var pairs = this.pairs_of[hashed];
       var cloned = _.map(pairs, function(pair){
         return _.clone(pair);
@@ -93,8 +93,8 @@ class Hashtable {
 
   _apply_pair(func){
     var a = [];
-    _.each(_.values(this.pairs_of), function(pairs){
-      _.each(pairs, function(pair){
+    Object.keys(this.pairs_of).map((key)=>this.pairs_of[key]).forEach(function(pairs){
+      pairs.forEach(function(pair){
         a.push(func(pair));
       });
     });

--- a/src/system/pair.js
+++ b/src/system/pair.js
@@ -215,8 +215,8 @@ const js_obj_to_alist = function(obj) {
     return nil;
   }
   var arr = [];
-  _.each(obj, function(val, key) {
-    arr.push(new Pair(key, val));
+  Object.keys(obj).forEach( function( key) {
+    arr.push(new Pair(key, obj[key]));
   });
   var alist = array_to_list(arr);
   return alist;

--- a/test/node_functions.js
+++ b/test/node_functions.js
@@ -90,9 +90,9 @@ var tests = {
   }
 };
 
-_.each(tests, function(func, name){
-  puts("- "+name);
-  func();
+Object.keys(tests).forEach(function(key){
+  puts("- "+key);
+  tests[key]();
 });
 
 puts("test ok");


### PR DESCRIPTION
Work in progress but wanted to create the PR so people know this is being worked on, and I have a few questions.

What is the proper way to load in jquery to pass tests while developing on biwa? As I go, I'm running tests and my browsers tests are failing due to $ being undefined. I'm also running into issues run `npm run build` due to jquery as well with output that says:

```
> npm run build

> biwascheme@0.7.4 build C:\Users\julia\code\biwascheme
> rollup -c


src/main-node.js → release/node_biwascheme.js...
(!) Circular dependencies
src\system\_writer.js -> src\system\pair.js -> src\system\_writer.js
src\system\_writer.js -> src\system\pair.js -> src\system\set.js -> src\system\error.js -> src\system\_writer.js
created release/node_biwascheme.js in 2.9s

src/main-browser.js → release/biwascheme.js, release/biwascheme-min.js, release/biwascheme.mjs...
(!) Circular dependencies
src\system\_writer.js -> src\system\pair.js -> src\system\_writer.js
src\system\_writer.js -> src\system\pair.js -> src\system\set.js -> src\system\error.js -> src\system\_writer.js
[!] (plugin rollup-plugin-prettier) SyntaxError: Unexpected token, expected ";" (6:14)
  4 |  * Copyright (c) 2007-2021 Yutaka HARA (http://www.biwascheme.org/)
  5 |  * Licensed under the MIT license.
> 6 |  */jquery-3.6.0.js
    |              ^
  7 | var BiwaScheme = (function () {
  8 |   //
  9 |   // variables
undefined (undefined:undefined)
SyntaxError: Unexpected token, expected ";" (6:14)
  4 |  * Copyright (c) 2007-2021 Yutaka HARA (http://www.biwascheme.org/)
  5 |  * Licensed under the MIT license.
> 6 |  */jquery-3.6.0.js
    |              ^
  7 | var BiwaScheme = (function () {
  8 |   //
  9 |   // variables
    at e (C:\Users\julia\code\biwascheme\node_modules\prettier\parser-babel.js:1:282)
    at Object.parse (C:\Users\julia\code\biwascheme\node_modules\prettier\parser-babel.js:1:262451)
    at Object.parse (C:\Users\julia\code\biwascheme\node_modules\prettier\index.js:11370:19)
    at coreFormat (C:\Users\julia\code\biwascheme\node_modules\prettier\index.js:14784:25)
    at format (C:\Users\julia\code\biwascheme\node_modules\prettier\index.js:15019:75)
    at formatWithCursor (C:\Users\julia\code\biwascheme\node_modules\prettier\index.js:15035:12)
    at C:\Users\julia\code\biwascheme\node_modules\prettier\index.js:51620:12
    at Object.format (C:\Users\julia\code\biwascheme\node_modules\prettier\index.js:51640:12)
    at RollupPluginPrettier.reformat (C:\Users\julia\code\biwascheme\node_modules\rollup-plugin-prettier\dist\index.js:110:29)
    at Object.renderChunk (C:\Users\julia\code\biwascheme\node_modules\rollup-plugin-prettier\dist\index.js:180:21)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! biwascheme@0.7.4 build: `rollup -c`
npm ERR! Exit status 1
```

Lastly, `_.escape` has no vanillajs equivalent, so I've created a helper file in system with the code from lodash (as its more straightforwad than underscores implementation of escape)

Is this how this should be handled?