### PR TITLE
Revert "Fix uses of eval to address rollup warnings"

### DIFF
--- a/src/library/js_interface.js
+++ b/src/library/js_interface.js
@@ -16,13 +16,8 @@ import { BiwaSymbol, Sym } from "../system/symbol.js"
 //
 // interface to javascript
 //
-
-// Rebind uses of eval to the global scope, to avoid polluting downstream code.
-// See: https://github.com/rollup/rollup/wiki/Troubleshooting#avoiding-eval
-let eval2 = eval;
-
 define_libfunc("js-eval", 1, 1, function(ar){
-  return eval2(ar[0]);
+  return eval(ar[0]);
 });
 define_libfunc("js-ref", 2, 2, function(ar){
   if(typeof ar[1] === "string" || Number.isInteger(ar[1])){
@@ -80,7 +75,7 @@ define_libfunc("js-invocation", 2, null, function(ar, intp){
   var receiver = ar.shift();
   // TODO: convert lambdas by js-closure 
   if(isSymbol(receiver)){
-    receiver = eval2(receiver.name); //XXX: is this ok?
+    receiver = eval(receiver.name); //XXX: is this ok?
   }
 
   var v = receiver;
@@ -167,7 +162,7 @@ define_libfunc("js-new", 1, null, function(ar, intp){
   };
 
   var ctor = ar.shift();
-  if (typeof ctor === "string") ctor = eval2(ctor);
+  if (typeof ctor === "string") ctor = eval(ctor);
 
   if(ar.length == 0){
     return new ctor();


### PR DESCRIPTION
This PR reverts commit c0eee4bed907767ac4eb2551a84d8168ed3d0586 to keep backward compatibility in v0.7.x. 

fix #275