### PR TITLE
new expander: impl. defineLibrary

### DIFF
--- a/src/header.js
+++ b/src/header.js
@@ -13,8 +13,6 @@ const nil = {
   to_write: function() { return "()"; },
   to_array: function() { return []; },
   length: function() { return 0; },
-  // Moved to main.js to avoid circular dependency
-  //to_set: function() { return new BiwaSet(); },
 };
 
 //

--- a/src/main.js
+++ b/src/main.js
@@ -41,9 +41,6 @@ import { assert_number, assert_integer, assert_real, assert_between, assert_stri
          assert_vector, assert_hashtable, assert_mutable_hashtable, assert_promise,
          assert_function, assert_closure, assert_procedure, assert_date, assert } from "./library/infra.js"
 
-// Avoid circular dependency
-nil.to_set = function(){ return new BiwaSet(); };
-
 export default {
   TopEnv, CoreEnv, nil, undef, max_trace_size, suppress_deprecation_warning,
   Version: VERSION, VERSION, GitCommit,

--- a/src/new_expander_dev.js
+++ b/src/new_expander_dev.js
@@ -7,7 +7,8 @@
 import { to_write } from "./system/_writer.js";
 import Call from "./system/call.js";
 import Parser from "./system/parser.js";
-import { array_to_list } from "./system/pair.js";
+import { List, array_to_list } from "./system/pair.js";
+import { Sym } from "./system/symbol.js";
 import { Library } from "./system/expander/library.js"
 import { Engine } from "./system/engine.js";
 
@@ -26,9 +27,26 @@ import "./library/r6rs_lib.js"
 //  .catch(console.log)
 
 // Example 2
-const engine = new Engine();
-console.log("=>", await engine.run(`
-(import (scheme base))
-(+ 1 2 3)
-`))
+//const engine = new Engine();
+//console.log("=>", await engine.run(`
+//(import (scheme base))
+//(+ 1 2 3)
+//`))
 
+// Example 3
+const engine = new Engine();
+await engine.defineLibrary(List(Sym("counter")), `
+(define-library (counter)
+  (import (scheme base))
+  (export get-count inc-count)
+  (begin
+    (define ct 0)
+    (define (get-count) ct)
+    (define (inc-count) (set! ct (+ ct 1)))))
+  `);
+console.log("")
+console.log("=>", await engine.run(`
+(import (scheme base) (counter))
+(inc-count)
+(get-count)
+`))

--- a/src/system/compiler.js
+++ b/src/system/compiler.js
@@ -110,7 +110,7 @@ class Compiler {
       case Sym("lambda"):
         var vars=x.second(), body=x.cdr.cdr;
         if (vars instanceof Pair){ // (lambda (...) ...)
-          ret = this.find_sets(body, v.set_minus(vars.to_set()));
+          ret = this.find_sets(body, v.set_minus(to_set(vars)));
         }
         else { // (lambda args ...)
           ret = this.find_sets(body, v.set_minus(new BiwaSet(vars)));
@@ -182,7 +182,7 @@ class Compiler {
       case Sym("lambda"):
         var vars=x.second(), body=x.cdr.cdr;
         if (vars instanceof Pair){ // (lambda (...) ...)
-          ret = this.find_free(body, b.set_union(vars.to_set()), f);
+          ret = this.find_free(body, b.set_union(to_set(vars)), f);
         }
         else { // (lambda args ...)
           ret = this.find_free(body, b.set_cons(vars), f);
@@ -490,13 +490,13 @@ class Compiler {
 
     var dotpos = this.find_dot_pos(vars);
     var proper = this.dotted2proper(vars);
-    var free = this.find_free(cbody, proper.to_set(), f); //free variables
-    var sets = this.find_sets(cbody, proper.to_set());    //local variables
+    var free = this.find_free(cbody, to_set(proper), f); //free variables
+    var sets = this.find_sets(cbody, to_set(proper));    //local variables
 
     var do_body = this.compile(cbody,
-                    [proper.to_set(), free],
+                    [to_set(proper), free],
                     sets.set_union(s.set_intersect(free)),
-                    f.set_union(proper.to_set()),
+                    f.set_union(to_set(proper)),
                     ["return"]);
     var do_close = ["close",
                      vars instanceof Pair ? vars.length() : 0,
@@ -676,5 +676,18 @@ Compiler.transform_internal_define = function(x){
   return new Pair(Sym("letrec*"),
            new Pair(bindings, exprs));
 };
+
+// Convert a list to BiwaSet
+function to_set(ls) {
+  if (ls === nil) {
+    return new BiwaSet();
+  } else {
+    var set = new BiwaSet();
+    for(var o = ls; o instanceof Pair; o=o.cdr){
+      set.add(o.car);
+    }
+    return set;
+  }
+}
 
 export default Compiler;

--- a/src/system/expander/core.js
+++ b/src/system/expander/core.js
@@ -108,7 +108,6 @@ const expandLambda = async ([form, xp, env]) => {
   const formals = form.cadr(err);
   if (!isList(formals)) throw err;
   const newIds = collectCarAndCdr(formals);
-  console.log("[newIds]", newIds);
   const newEnv = env.extended(newIds);
   
   const newFormals = formals === nil
@@ -144,7 +143,6 @@ function _expandDefinitionBodyInLambda(body) {
 
 // Splice internal defines enclosed with `begin`
 function _spliceDefinitionInLambda(body) {
-  console.log("[body]", to_write(body));
   const definitions = [];
   const rest = [];
   for (const form of body.to_array()) {

--- a/src/system/expander/core.js
+++ b/src/system/expander/core.js
@@ -1,8 +1,11 @@
 //
 // Expanders for core syntaxes
 //
-import { List, Cons, isPair, isList } from "../pair.js"
+import { nil } from "../../header.js"
+import { List, Cons, isPair, isList, array_to_list, mapCarAndCdr, collectCarAndCdr } from "../pair.js"
 import { Sym } from "../symbol.js"
+import { to_write } from "../_writer.js"
+import { Bug, BiwaError } from "../error.js"
 import { isIdentifier, unwrapSyntax } from "./syntactic_closure.js"
 import { identifierEquals } from "./environment.js"
 import { makeErMacroTransformer } from "./macro_transformer.js"
@@ -42,18 +45,25 @@ const expandDefine = async ([form, xp, env]) => {
   const l = form.to_array();
   switch (l.length) {
     case 3:
-      const [_, formal, expr] = l;
-      if (!isIdentifier(formal)) {
-        throw new BiwaError("malformed define", form);
+      const [_, formal, ...exprs] = l;
+      if (isIdentifier(formal) && exprs.length == 1) {
+        // (define var expr)
+        env.extend(formal);
+        const id = await xp.expand(formal);
+        const body = env.isToplevel() ? (await xp.expand(exprs[0]))
+                                      : exprs[0]; // Expand later on
+        return List(Sym("define"), id, body);
+      } else if (isPair(formal)) {
+        const id = formal.car;
+        if (isIdentifier(id)) {
+          const args = formal.cdr;
+          const form = List(Sym("define"), id,
+            Cons(Sym("lambda"), Cons(args, array_to_list(exprs))));
+          return expandDefine([form, xp, env]);
+        }
       }
-      env.extend(formal);
-      const id = await xp.expand(formal);
-      const body = env.isToplevel() ? (await xp.expand(expr))
-                                    : expr; // Expand later on
-      return List(Sym("define"), id, body);
-    default:
-      throw new BiwaError("malformed define", form);
   }
+  throw new BiwaError("malformed define", form);
 };
 
 // `define-syntax`
@@ -87,21 +97,89 @@ const expandIf = async ([form, xp]) => {
 };
 
 // `lambda`
-const expandLambda = async ([form, xp]) => {
+// - (lambda (x y) ...)
+// - (lambda (x y . rest) ...)
+// - (lambda args ...)
+const expandLambda = async ([form, xp, env]) => {
   const err = new BiwaError("malformed lambda", form);
   const l = form.to_array();
   if (l.length < 3) throw err;
+
   const formals = form.cadr(err);
-  if (!isPair(formals)) throw err;
+  if (!isList(formals)) throw err;
+  const newIds = collectCarAndCdr(formals);
+  console.log("[newIds]", newIds);
+  const newEnv = env.extended(newIds);
+  
+  const newFormals = formals === nil
+    ? nil
+    : mapCarAndCdr(formals, async (x) => { return await xp.expand(x) });
+
   const body = form.cddr(err);
+  let newBody = await body.mapAsync(async form => { return await xp.expand(form, newEnv) });
+  newBody = _expandDefinitionBodyInLambda(newBody);
+  newBody = _spliceDefinitionInLambda(newBody);
 
-  const newEnv = env.extend(formal-list);
+  return Cons(Sym("lambda"), Cons(newFormals, newBody));
+}
 
-  // TODO
+/** Process bodies of internal define
+ * @return Form
+ */
+function _expandDefinitionBodyInLambda(body) {
+  const err = new BiwaError("malformed define in lambda", body);
+  return body.mapList(form => {
+    if (!isPair(form)) return form;
+    const car = form.car;
+    if (car === Sym("quote") || car == Sym("lambda")) return form;
+    if (car === Sym("define")) {
+      const k = form.cadr(err);
+      const v = form.caddr(err);
+      return List(Sym("define"), k, _expandDefinitionBodyInLambda(v));
+    } else {
+      return _expandDefinitionBodyInLambda(form);
+    }
+  });
+}
 
-  return Cons(Sym("lambda"),
-           Cons(newFormals, newBody));
-};
+// Splice internal defines enclosed with `begin`
+function _spliceDefinitionInLambda(body) {
+  console.log("[body]", to_write(body));
+  const definitions = [];
+  const rest = [];
+  for (const form of body.to_array()) {
+    if (rest.length > 0 || !_isDefinition(form)) {
+      rest.push(form);
+    } else {
+      definitions = definitions.concat(_spliceDefinition(form));
+    }
+  }
+  return array_to_list(definitions.concat(rest))
+}
+
+function _isDefinition(form) {
+  if (!isPair(form)) return false;
+  if (form.car === Sym("define") ||
+      form.car === Sym("define-record-type")) {
+    return true;
+  } else if (form.car === Sym("begin") && 
+             form.cdr.to_array().all(_isDefinition)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+// Removes `begin`. Returns an array of define/define-record-type
+function _spliceDefinition(def) {
+  if (form.car === Sym("define") ||
+      form.car === Sym("define-record-type")) {
+    return [form];
+  } else {
+    if (form.car !== Sym("begin")) throw new Bug("unexpected");
+    return form.cdr.to_array().map(_spliceDefinition);
+  }
+}
 
 // `let-syntax`
 const expandLetSyntax = async ([form, xp, env, metaEnv]) => {

--- a/src/system/expander/environment.js
+++ b/src/system/expander/environment.js
@@ -32,10 +32,14 @@ let lastId = 0;
 class Environment {
   /**
    * Create a toplevel binding
-   * @param {string} name
-   * @param {(BiwaSymbol) => BiwaSymbol} renamer
+   * @param {?string} name
+   * @param {?string} prefix (pass `null` when specifying renamer)
+   * @param {?(BiwaSymbol) => BiwaSymbol} renamer
    */
-  static makeToplevelEnvironment(name, renamer) {
+  static makeToplevelEnvironment(name, prefix = null, renamer = null) {
+    if (prefix !== null) {
+      renamer = sym => Sym(`${prefix}${sym.name}`);
+    }
     return new Environment(name, null, new Map(), renamer);
   }
 
@@ -151,8 +155,11 @@ class Environment {
     this.set(id, generateName(id));
   }
 
-  // Create an enviroment by adding `ids` to this enviroment
-  // original: `extend-enviroment`
+  /* Create an enviroment by adding `ids` to this enviroment
+   * original: `extend-enviroment`
+   * @param {ids} [Identifier]
+   * @return Environment
+   */
   extended(ids) {
     const newEnv = new Environment("", this);
     ids.forEach(id => newEnv.extend(id));

--- a/src/system/libraries.js
+++ b/src/system/libraries.js
@@ -6,7 +6,7 @@ import { libSchemeBase } from "../r7rs/base.js"
 const mangle = (spec) => spec.to_write;
 class Libraries {
   constructor() {
-    this.libraries = new Map();
+    this.libraries = new Map(); // spec => BiwaScheme.Library
   }
   
   get(spec) {

--- a/src/system/pair.js
+++ b/src/system/pair.js
@@ -17,17 +17,17 @@ class Pair {
   // throws `err`.
   caar(err){ return this._get(["car", "car"], err) }
   cadr(err){ return this._get(["cdr", "car"], err) }
-  cdar(err){ return this._get(["cdr", "car"], err) }
+  cdar(err){ return this._get(["car", "cdr"], err) }
   cddr(err){ return this._get(["cdr", "cdr"], err) }
-  _get(props, err) {
+  _get(props, err="unexpected") {
     let x = this;
-    props.forEach(p => {
+    for (const p of props) {
       if (x.hasOwnProperty(p)) {
-        return x[p];
-      } else if (err) {
+        x = x[p];
+      } else {
         throw err;
       }
-    });
+    }
     return x;
   }
 

--- a/src/system/pair.js
+++ b/src/system/pair.js
@@ -273,5 +273,34 @@ const alist_to_js_obj = function(alist) {
   return obj;
 };
 
+// Returns a new list made by applying `f` to each `car` and the last `cdr`
+const mapCarAndCdr = function(ls, f) {
+  if (ls === nil) {
+    return f(nil);
+  } else {
+    return Cons(f(ls.car), mapCarAndCdr(ls.cdr, f));
+  }
+};
+
+// Returns an array of each `car` and the last `cdr`, if it is not nil.
+const collectCarAndCdr = function(ls, f) {
+  if (ls === nil) {
+    return [];
+  } else {
+    return [ls.car].concat(collectCarAndCdr(ls.cdr));
+  }
+};
+
+/** Apply async function to each item of the list one by one.
+ * Returns a list of the results.
+ */
+async function mapAsync(ls, func) {
+  const ary = [];
+  for (var o = ls; isPair(o); o = o.cdr) {
+    ary.push(await func(o.car));
+  }
+  return array_to_list(ary);
+}
+
 export { Pair, List, isPair, isList, concatLists, array_to_list, deep_array_to_list, Cons,
-         js_obj_to_alist, alist_to_js_obj };
+         js_obj_to_alist, alist_to_js_obj, mapCarAndCdr, collectCarAndCdr, mapAsync };

--- a/src/system/pair.js
+++ b/src/system/pair.js
@@ -48,14 +48,6 @@ class Pair {
     return ary;
   }
 
-  to_set(){
-    var set = new BiwaSet();
-    for(var o = this; o instanceof Pair; o=o.cdr){
-      set.add(o.car);
-    }
-    return set;
-  }
-
   length(){
     var n = 0;
     for(var o = this; o instanceof Pair; o=o.cdr){


### PR DESCRIPTION
This PR implements `Engine.defineLibrary`. Example:

```js
const engine = new Engine();                                                       
await engine.defineLibrary(List(Sym("counter")), `                                 
(define-library (counter)                                                          
  (import (scheme base))                                                           
  (export get-count inc-count)                                                     
  (begin                                                                           
    (define ct 0)                                                                  
    (define (get-count) ct)                                                        
    (define (inc-count) (set! ct (+ ct 1)))))                                      
  `);

// Prints 1
console.log("=>", await engine.run(`
(import (scheme base) (counter))
(inc-count)
(get-count)
`))
```
refs #281