### PR TITLE
Allow ,@non-list for last item

### DIFF
--- a/src/library/r6rs_lib.js
+++ b/src/library/r6rs_lib.js
@@ -1356,10 +1356,15 @@ var expand_qq = function(f, lv){
   else if(f instanceof Pair){
     var car = f.car;
     if(car instanceof Pair && car.car === Sym("unquote-splicing")){
-      if(lv == 1)
-        return List(Sym("append"),
-                    f.car.cdr.car,
-                    expand_qq(f.cdr, lv));
+      if(lv == 1) {
+        if (f.cdr === nil) {
+          return f.car.cdr.car;
+        } else {
+          return List(Sym("append"),
+                      f.car.cdr.car,
+                      expand_qq(f.cdr, lv));
+        }
+      }
       else
         return List(Sym("cons"),
                     List(Sym("list"),

--- a/test/unit.js
+++ b/test/unit.js
@@ -1374,6 +1374,9 @@ describe('11.17  Quasiquotation', {
   'vector (nested)' : function(){
     ew("(let1 ls '(4) `#(1 `#(2 ,#(3 ,@ls))))")
       .should_be("#(1 (quasiquote #(2 (unquote #(3 4)))))");
+  },
+  'not a list' : function() {
+    ew("`(,1 ,@2)").should_be("(1 . 2)");
   }
 })
 


### PR DESCRIPTION
This PR fixes #101 by allowing `,@x` where x is not a list if it is the last item in the quasiquote.