### PR TITLE
Add base macros

### DIFF
--- a/src/system/expander/environment.js
+++ b/src/system/expander/environment.js
@@ -204,11 +204,6 @@ class Environment {
   }
 }
 
-// Returns whether `id1` in `env1` and `id2` in `id2` is the same identifier
-const identifierEquals = (id1, env1, id2, env2) => {
-  return env1.expand(id1) === env2.expand(id2);
-};
-
 // Returns a newly created unique symbol
 let generateNameN = 0;
 const generateName = id => {
@@ -217,4 +212,4 @@ const generateName = id => {
   return Sym(`%${unwrapSyntax(id)}.${n}`);
 }
 
-export { Environment, identifierEquals };
+export { Environment };

--- a/src/system/expander/expander.js
+++ b/src/system/expander/expander.js
@@ -146,6 +146,12 @@ class Expander {
     });
   }
 
+  // Returns whether `id1` in `env1` and `id2` in `id2` is the same identifier
+  async identifierEquals(id1, env1, id2, env2) {
+    const l = await this.expand(id1, env1);
+    const r = await this.expand(id2, env2);
+    return l === r;
+  }
 }
 
 export { Expander };

--- a/src/system/expander/expander.js
+++ b/src/system/expander/expander.js
@@ -148,6 +148,8 @@ class Expander {
 
   // Returns whether `id1` in `env1` and `id2` in `id2` is the same identifier
   async identifierEquals(id1, env1, id2, env2) {
+    if (!isIdentifier(id1) || !isIdentifier(id2)) return false;
+
     const l = await this.expand(id1, env1);
     const r = await this.expand(id2, env2);
     return l === r;

--- a/src/system/expander/macro_transformer.js
+++ b/src/system/expander/macro_transformer.js
@@ -13,7 +13,7 @@ function makeErMacroTransformer(proc) {
         return id
       }
     };
-    const compare = (x, y) => xp.identifierEquals(x, env, y, env);
+    const compare = async (x, y) => xp.identifierEquals(x, env, y, env);
     const result = await xp.engine.invoke(proc, [form, rename, compare]);
     return xp.expand(result);
   };

--- a/src/system/expander/macro_transformer.js
+++ b/src/system/expander/macro_transformer.js
@@ -1,4 +1,4 @@
-import { Environment, identifierEquals } from "./environment.js"
+import { Environment } from "./environment.js"
 
 // Explicit-renaming macro
 function makeErMacroTransformer(proc) {
@@ -13,7 +13,7 @@ function makeErMacroTransformer(proc) {
         return id
       }
     };
-    const compare = (x, y) => identifierEquals(x, env, y, env);
+    const compare = (x, y) => xp.identifierEquals(x, env, y, env);
     const result = await xp.engine.invoke(proc, [form, rename, compare]);
     return xp.expand(result);
   };

--- a/src/system/expander/macro_transformer.js
+++ b/src/system/expander/macro_transformer.js
@@ -4,7 +4,7 @@ import { Environment, identifierEquals } from "./environment.js"
 function makeErMacroTransformer(proc) {
   return async function([form, xp, env, metaEnv]) {
     const table = new Map();
-    const rename = ([x]) => {
+    const rename = (x) => {
       if (table.has(x)) {
         return table.get(x)
       } else {
@@ -13,7 +13,7 @@ function makeErMacroTransformer(proc) {
         return id
       }
     };
-    const compare = ([x, y]) => identifierEquals(x, env, y, env);
+    const compare = (x, y) => identifierEquals(x, env, y, env);
     const result = await xp.engine.invoke(proc, [form, rename, compare]);
     return xp.expand(result);
   };


### PR DESCRIPTION
refs #281

This PR adds some basic macros to (scheme base).

Also, `compare` is changed to be async function because it calls .expand internally.