### PR TITLE
new expander fixes

### DIFF
--- a/src/new_expander_dev.js
+++ b/src/new_expander_dev.js
@@ -4,7 +4,7 @@
 //   $ node ./src/new_expander_dev.js
 // See https://github.com/biwascheme/biwascheme/pull/192#issuecomment-673534970
 // if it doesn't work
-import { to_write } from "./system/_writer.js";
+import { inspect } from "./system/_writer.js";
 import Call from "./system/call.js";
 import Parser from "./system/parser.js";
 import { List, array_to_list } from "./system/pair.js";
@@ -33,20 +33,39 @@ import "./library/r6rs_lib.js"
 //(+ 1 2 3)
 //`))
 
-// Example 3
+
+// Example 3: defining a library
+// const engine = new Engine();
+// await engine.defineLibrary(List(Sym("counter")), `
+// (define-library (counter)
+//   (import (scheme base))
+//   (export get-count inc-count)
+//   (begin
+//     (define ct 0)
+//     (define (get-count) ct)
+//     (define (inc-count) (set! ct (+ ct 1)))))
+//   `);
+// console.log("")
+// console.log("=>", await engine.run(`
+// (import (scheme base) (counter))
+// (inc-count)
+// (get-count)
+// `))
+
+// Example 4: library-local name
 const engine = new Engine();
-await engine.defineLibrary(List(Sym("counter")), `
-(define-library (counter)
+await engine.defineLibrary(List(Sym("utils")), `
+(define-library (utils)
   (import (scheme base))
-  (export get-count inc-count)
+  (export log)
   (begin
-    (define ct 0)
-    (define (get-count) ct)
-    (define (inc-count) (set! ct (+ ct 1)))))
+    (define msgs '())
+    (define (log msg) (set! msgs (cons msg msgs)))))
   `);
 console.log("")
 console.log("=>", await engine.run(`
-(import (scheme base) (counter))
-(inc-count)
-(get-count)
+(import (utils) (scheme base))
+(define msgs "ok")
+(log "hello")  ; Does not overwrite the our msgs
+msgs
 `))

--- a/src/system/_writer.js
+++ b/src/system/_writer.js
@@ -92,6 +92,13 @@ const inspect = function(object, opts) {
     if (Array.isArray(object)) {
       return '[' + object.map(inspect).join(', ') + ']';
     }
+    if (object instanceof Map) {
+      var s = "#<Map";
+      for (const [k, v] of object) {
+        s += ` ${inspect(k, opts)}: ${inspect(v, opts)}`;
+      }
+      return s + ">";
+    }
 
     if (opts && opts["fallback"]){
       return opts["fallback"];

--- a/src/system/expander/core.js
+++ b/src/system/expander/core.js
@@ -2,7 +2,7 @@
 // Expanders for core syntaxes
 //
 import { nil } from "../../header.js"
-import { List, Cons, isPair, isList, array_to_list, mapCarAndCdr, collectCarAndCdr } from "../pair.js"
+import { List, Cons, isPair, isList, array_to_list, mapCarAndCdrAsync, collectCarAndCdr } from "../pair.js"
 import { Sym } from "../symbol.js"
 import { to_write } from "../_writer.js"
 import { Bug, BiwaError } from "../error.js"
@@ -111,7 +111,7 @@ const expandLambda = async ([form, xp, env]) => {
   
   const newFormals = formals === nil
     ? nil
-    : mapCarAndCdr(formals, async (x) => { return await xp.expand(x) });
+    : await mapCarAndCdrAsync(formals, async (x) => { return await xp.expand(x) });
 
   const body = form.cddr(err);
   let newBody = await body.mapAsync(async form => { return await xp.expand(form, newEnv) });

--- a/src/system/expander/library.js
+++ b/src/system/expander/library.js
@@ -1,6 +1,6 @@
 import { nil } from "../../header.js";
 import { isSymbol, isVector } from "../_types.js"
-import { to_write } from "../_writer.js"
+import { to_write, inspect } from "../_writer.js"
 import { Bug, BiwaError } from "../error.js"
 import { List, array_to_list, Cons, isPair, isList } from "../pair.js"
 import { Sym } from "../symbol.js"
@@ -13,15 +13,20 @@ class Library {
   static currentLibrary = null;
   static featureList = [];
 
-  constructor(environment) {
+  constructor(environment, name) {
     this.environment = environment;
+    this.name = name;  // For debugging purpose
     this.exports = new Map();
+  }
+
+  toString() {
+    return `#<Library ${this.name}(${this.exports.size})>`;
   }
 
   static create(spec) {
     const name = spec.map(x => to_write(x)).join(".");
     const env = Environment.makeToplevelEnvironment(name, `${name}:`);
-    return new Library(env);
+    return new Library(env, name);
   }
 
   /** Interprets imports, exports, etc. of this library

--- a/src/system/expander/macro.js
+++ b/src/system/expander/macro.js
@@ -22,7 +22,7 @@ class Macro {
     }
   }
 
-  to_write() {
+  toString() {
     return `#<Macro ${this.dbgName}>`
   }
 }

--- a/src/system/libraries.js
+++ b/src/system/libraries.js
@@ -1,9 +1,10 @@
 import { List } from "./pair.js"
 import { Sym } from "./symbol.js"
 import { BiwaError, Bug } from "./error.js"
+import { to_write } from "./_writer.js"
 import { libSchemeBase } from "../r7rs/base.js"
 
-const mangle = (spec) => spec.to_write;
+const mangle = (spec) => to_write(spec);
 class Libraries {
   constructor() {
     this.libraries = new Map(); // spec => BiwaScheme.Library

--- a/src/system/pair.js
+++ b/src/system/pair.js
@@ -274,6 +274,15 @@ const mapCarAndCdr = function(ls, f) {
   }
 };
 
+// Returns a new list made by applying `f` to each `car` and the last `cdr`
+const mapCarAndCdrAsync = async function(ls, f) {
+  if (ls === nil) {
+    return await f(nil);
+  } else {
+    return Cons(await f(ls.car), await mapCarAndCdrAsync(ls.cdr, f));
+  }
+};
+
 // Returns an array of each `car` and the last `cdr`, if it is not nil.
 const collectCarAndCdr = function(ls, f) {
   if (ls === nil) {
@@ -295,4 +304,4 @@ async function mapAsync(ls, func) {
 }
 
 export { Pair, List, isPair, isList, concatLists, array_to_list, deep_array_to_list, Cons,
-         js_obj_to_alist, alist_to_js_obj, mapCarAndCdr, collectCarAndCdr, mapAsync };
+         js_obj_to_alist, alist_to_js_obj, mapCarAndCdr, mapCarAndCdrAsync, collectCarAndCdr, mapAsync };


### PR DESCRIPTION
This PR fixes some bugs of the new expander. Now this example works as expected:

```js
const engine = new Engine();
await engine.defineLibrary(List(Sym("utils")), `
(define-library (utils)
  (import (scheme base))
  (export log)
  (begin
    (define msgs '())
    (define (log msg) (set! msgs (cons msg msgs)))))
  `);
console.log("")
console.log("=>", await engine.run(`
(import (utils) (scheme base))
(define msgs "ok")
(log "hello")  ; Does not overwrite the our msgs
msgs
`))
```