### PR TITLE
Rename and compare for er-macro-transfomer

### DIFF
--- a/src/new_expander_dev.js
+++ b/src/new_expander_dev.js
@@ -78,14 +78,34 @@ Port.current_error = current_error;
 //`))
 
 // Example 5: ER macro
+//const engine = new Engine();
+//console.log("=>", await engine.run(`
+//(import (scheme base) (scheme cxr) (scheme write) (biwascheme er-macro))
+//(define-syntax assert-equal
+//  (er-macro-transformer
+//    (lambda (form rename compare)
+//      \`(unless (equal? ,(cadr form) ,(caddr form))
+//        (display "failed: ")
+//        (write ',(cdr form))))))
+//(assert-equal (+ 1 2) 4)
+//`))
+
+// Example 6: Exporting a macro
 const engine = new Engine();
+await engine.defineLibrary(List(Sym("assert")), `
+ (define-library (assert)
+   (import (scheme base) (biwascheme er-macro)  (scheme cxr) (scheme write))
+   (export assert-equal)
+   (begin
+     (define-syntax assert-equal
+       (er-macro-transformer
+         (lambda (form rename compare)
+           \`(unless (equal? ,(cadr form) ,(caddr form))
+             (,(rename display) "failed: ")
+             (,(rename write) ',(cdr form))))))))
+   `);
+console.log("")
 console.log("=>", await engine.run(`
-(import (scheme base) (scheme cxr) (scheme write) (biwascheme er-macro))
-(define-syntax assert-equal
-  (er-macro-transformer
-    (lambda (form rename compare)
-      \`(unless (equal? ,(cadr form) ,(caddr form))
-        (display "failed: ")
-        (write ',(cdr form))))))
+(import (scheme base)(assert))
 (assert-equal (+ 1 2) 4)
 `))

--- a/src/system/expander/expander.js
+++ b/src/system/expander/expander.js
@@ -6,6 +6,7 @@ import { Cons, List, isPair, isList, array_to_list, mapAsync } from "../pair.js"
 import { Sym } from "../symbol.js"
 import { isSyntacticClosure, isIdentifier } from "./syntactic_closure.js"
 import { isMacro } from "./macro.js"
+import { Environment } from "./environment.js"
 
 class Expander {
   constructor(engine) {

--- a/src/system/expander/macro_transformer.js
+++ b/src/system/expander/macro_transformer.js
@@ -1,19 +1,9 @@
-import { Environment } from "./environment.js"
+import { makeCompareAndRename } from "./macro.js";
 
 // Explicit-renaming macro
 function makeErMacroTransformer(proc) {
   return async function([form, xp, env, metaEnv]) {
-    const table = new Map();
-    const rename = (x) => {
-      if (table.has(x)) {
-        return table.get(x)
-      } else {
-        const id = metaEnv.makeIdentifier(x);
-        table.set(x, id);
-        return id
-      }
-    };
-    const compare = async (x, y) => xp.identifierEquals(x, env, y, env);
+    const [compare, rename] = makeCompareAndRename(xp, env, metaEnv)
     const result = await xp.engine.invoke(proc, [form, rename, compare]);
     return xp.expand(result);
   };


### PR DESCRIPTION
This PR implements `rename` and `compare` used with er-macro-transformer.