### PR TITLE
Refactor expander

### DIFF
--- a/src/lib/biwascheme/er-macro.js
+++ b/src/lib/biwascheme/er-macro.js
@@ -2,6 +2,16 @@
 import { Library } from "../../system/expander/library.js"
 import { List } from "../../system/pair.js"
 import { Sym } from "../../system/symbol.js"
+import { define_libfunc, alias_libfunc, define_syntax, define_scmfunc,
+         assert_number, assert_integer, assert_real, assert_between, assert_string,
+         assert_char, assert_symbol, assert_port, assert_pair, assert_list,
+         assert_function, assert_closure, assert_procedure, assert_date, assert, deprecate } from "../../library/infra.js"; 
+import { ErMacroTransformer } from "../../system/expander/macro_transformer.js"
+
+define_libfunc("er-macro-transformer", 1, 1, function(ar) {
+  assert_procedure(ar[0]);
+  return new ErMacroTransformer(ar[0]);
+});
 
 const libBiwaschemeErMacro = Library.create(List(Sym('biwascheme'), Sym('er-macro')));
 const exports = [

--- a/src/system/engine.js
+++ b/src/system/engine.js
@@ -69,14 +69,15 @@ class Engine {
     return intp.evaluate_vmcode(vmcode); //TODO: this should return Promise
   }
 
-  // Invoke a procedure
-  // If proc is a JS function, args must be an array of Scheme values
-  // If proc is a Scheme function, args must be a list of Scheme values
+  // Invoke a procedure 
+  // `args` must be an array of Scheme values
   async invoke(proc, args) {
     if (isFunction(proc)) {
       return proc(args, this);
     } else {
-      return this.evalExpandedForm(Cons(proc, args))
+      const intp = new Interpreter();
+      intp.on_error = (e) => { throw e };
+      return intp.invoke_closure(proc, args);
     }
   }
 

--- a/src/system/expander/expander.js
+++ b/src/system/expander/expander.js
@@ -8,6 +8,23 @@ import { isSyntacticClosure, isIdentifier } from "./syntactic_closure.js"
 import { isMacro } from "./macro.js"
 import { Environment } from "./environment.js"
 
+// Debug log
+var lv = 0;
+var lastDec = false;
+function DEBUG(from, to=null) {
+  return; // Comment out this to enable
+
+  if (to === null) {
+    console.log("  ".repeat(lv), "--", to_write(from))
+    lv += 1;
+    lastDec = false;
+  } else {
+    lv -= 1;
+    lastDec = true;
+    console.log("  ".repeat(lv), "=>", to_write(to))
+  }
+}
+
 class Expander {
   constructor(engine) {
     this.engine = engine;
@@ -81,6 +98,7 @@ class Expander {
   }
 
   async expand(form, env=this.engine.currentToplevelEnvironment) {
+    DEBUG(form);
     let ret;
     if (isIdentifier(form)) {
       ret = this._expandIdentifier(form, env);
@@ -116,7 +134,7 @@ class Expander {
     else {
       throw new BiwaError("expand: invalid expression", form);
     }
-    //console.log("---", to_write(form), "\n ->", to_write(ret));
+    DEBUG(form, ret);
     return ret;
   }
 

--- a/src/system/expander/expander.js
+++ b/src/system/expander/expander.js
@@ -165,7 +165,7 @@ class Expander {
   }
 
   async _expandMacro(macro, form, env) {
-    return await macro.transform(form, env, macro.environment, this);
+    return await macro.transformer.transform(form, this, env, macro.environment);
   }
 
   /** Called when loading a library from file (or something)

--- a/src/system/expander/macro.js
+++ b/src/system/expander/macro.js
@@ -1,23 +1,8 @@
 import Call from "../call.js"
-import { inspect } from "../_writer.js";
+import { inspect, to_write } from "../_writer.js";
 import { List } from "../pair.js"
 import { Sym } from "../symbol.js"
 import { isFunction } from "../_types.js"
-
-function makeCompareAndRename(xp, env, metaEnv) {
-  const compare = async (x, y) => xp.identifierEquals(x, env, y, env);
-  const table = new Map();
-  const rename = (x) => {
-    if (table.has(x)) {
-      return table.get(x)
-    } else {
-      const id = metaEnv.makeIdentifier(x);
-      table.set(x, id);
-      return id
-    }
-  };
-  return [compare, rename]
-}
 
 // A macro expander (pair of transformer and environment)
 class Macro {
@@ -25,36 +10,16 @@ class Macro {
   constructor(dbgName, environment, transformer, isCoreSyntax) {
     this.environment = environment; // An `Environment`
     this.dbgName = dbgName; // String (for debugging use; may be empty)
-    // Either of
-    // - Js function `([form, expander, env, metaEnv]) => newForm`
-    // - Scheme proc `(lambda (form rename compare)) ... newForm)`
-    this.transformer = transformer;
+    this.transformer = transformer; // A MacroTransformer
     // True if this is a core syntax like `if`, `begin`, etc.
     this.isCoreSyntax = isCoreSyntax;
   }
 
-  async transform(form, env, metaEnv, expander) {
-    if (isFunction(this.transformer)) {
-      // transformer is a JS function
-      const args = [form, expander, env, metaEnv];
-      return this.transformer(args);
-    } else {
-      // transformer is a Scheme proc
-      const [compare_, rename_] = makeCompareAndRename(expander, env, metaEnv)
-      const compare = async ([x, y]) => await compare_(x, y)
-      const rename = ([x]) => rename_(x)
-      const args = List(List(Sym("quote"), form), rename, compare);
-      const expanded = await expander.engine.invoke(this.transformer, args);
-      //console.log(inspect(form), "~>", inspect(expanded));
-      return expanded;
-    }
-  }
-
   toString() {
-    return `#<Macro ${this.dbgName}>`
+    return `#<Macro ${this.dbgName} ${this.transformer}>`
   }
 }
 
 const isMacro = obj => obj instanceof Macro;
 
-export { Macro, isMacro, makeCompareAndRename };
+export { Macro, isMacro };

--- a/src/system/expander/macro_transformer.js
+++ b/src/system/expander/macro_transformer.js
@@ -1,12 +1,85 @@
-import { makeCompareAndRename } from "./macro.js";
+import { to_write, inspect } from "../_writer.js"
+import { List, Pair, isPair, array_to_list } from "../pair.js"
+import { Sym } from "../symbol.js"
 
-// Explicit-renaming macro
-function makeErMacroTransformer(proc) {
-  return async function([form, xp, env, metaEnv]) {
-    const [compare, rename] = makeCompareAndRename(xp, env, metaEnv)
-    const result = await xp.engine.invoke(proc, [form, rename, compare]);
-    return xp.expand(result);
+function makeCompareAndRename(xp, env, metaEnv) {
+  const compare = async (x, y) => xp.identifierEquals(x, env, y, env);
+  const table = new Map();
+  const rename = (x) => {
+    if (table.has(x)) {
+      return table.get(x)
+    } else {
+      const id = metaEnv.makeIdentifier(x);
+      table.set(x, id);
+      return id
+    }
   };
+  return [compare, rename]
 }
 
-export { makeErMacroTransformer };
+
+class MacroTransformer {
+  async transform(form, xp, env, metaEnv) {
+    throw "override me"
+  }
+}
+
+// For core syntaxes
+class NativeMacroTransformer extends MacroTransformer {
+  constructor(f) {
+    super();
+    this.f = f;
+  }
+
+  async transform(form, xp, env, metaEnv) {
+    return this.f([form, xp, env, metaEnv])
+  }
+
+  toString() {
+    return "#<NativeMacroTransformer>"
+  }
+}
+
+// Explicit renaming macros
+class ErMacroTransformer extends MacroTransformer {
+  constructor(proc) {
+    super();
+    // A Scheme procedure i.e. either of
+    // - (lambda (form rename compare) ...)
+    // - function([form, rename, compare]){ ... }
+    this.proc = proc;
+  }
+
+  async transform(form, xp, env, metaEnv) {
+    const [compare_, rename_] = makeCompareAndRename(xp, env, metaEnv)
+    const compare = async ([x, y]) => compare_(x, y);
+    const rename = ([x]) => rename_(x);
+    const result = await xp.engine.invoke(this.proc, [form, rename, compare]);
+    return xp.expand(result);
+  }
+
+  toString() {
+    return "#<ErMacroTransformer>"
+  }
+}
+
+// Explicit renaming macros, but intended to be used via JavaScript
+class JsErMacroTransformer extends MacroTransformer {
+  constructor(func) {
+    super();
+    // async function(form, rename, compare){ ... }
+    this.func = func;
+  }
+
+  async transform(form, xp, env, metaEnv) {
+    const [compare, rename] = makeCompareAndRename(xp, env, metaEnv)
+    const result = await this.func(form, rename, compare);
+    return xp.expand(result);
+  }
+
+  toString() {
+    return "#<JsErMacroTransformer>"
+  }
+}
+
+export { MacroTransformer, NativeMacroTransformer, ErMacroTransformer, JsErMacroTransformer };


### PR DESCRIPTION
This PR adds class MacroTransformer.

- NativeMacroTransformer: takes `form, xp, env, metaEnv`. Used for implementing core syntaxes.
- JsErMacroTransformer: takes `form, rename, compare` where rename and compare is a JS function. Used for implementing macros in JS.
- ErMacroTransformer: Used when `er-macro-transformer` is called from Scheme. Takes `form, rename, compare` but rename and compare is a Scheme procedure. 
 
refs #281