### PR TITLE
Support multi-value unquote

### DIFF
--- a/src/library/r6rs_lib.js
+++ b/src/library/r6rs_lib.js
@@ -1368,6 +1368,8 @@ const expandQuasiquote = function(x, depth){
       } else {
         throw new BiwaError("invalid use of quasiquote");
       }
+    } else if (x.cdr === nil) {
+      return expandQqList(x.car, depth);
     } else {
       // Use `append` because there may be a `,@` in the list
       return List(Sym("append"),

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,11 +1,26 @@
 import BiwaScheme from "../src/main.js"
 
+// Default error handler
 var on_error = function(e){
   console.warn(e);
   throw e;
 }
-function ev(str, func) {
-  return expect((new BiwaScheme.Interpreter(on_error)).evaluate(str, func||new Function()));
+
+// Evaluates `str` and returns the resulting Scheme value
+function evaluate(str, func) {
+  return (new BiwaScheme.Interpreter(on_error)).evaluate(str, func||new Function());
 }
 
-export { ev }
+// Evaluates `str` and returns expectation
+function ev(str, func) {
+  const v = evaluate(str, func);
+  return expect(v);
+}
+
+// Same as ev but makes the result into a string by to_write
+function ew(str, func) {
+  const v = evaluate(str, func);
+  return expect(BiwaScheme.to_write(v));
+}
+
+export { ev, ew }

--- a/test/r7rs/base.test.js
+++ b/test/r7rs/base.test.js
@@ -30,6 +30,9 @@ describe('4.2.8 Quasiquotation', () => {
   test('not a list', () => {
     ew("`(,1 ,@2)").toBe("(1 . 2)");
   })
+  test('bug #346', () => {
+    ew("(define l '(x y)) ``(,@,@l ,@,@l)").toBe("(quasiquote ((unquote-splicing x y) (unquote-splicing x y)))");
+  })
 })
 
 describe('6.6 Characters', () => {

--- a/test/r7rs/base.test.js
+++ b/test/r7rs/base.test.js
@@ -1,4 +1,36 @@
-import { ev } from "../helper.js"
+import { ev, ew } from "../helper.js"
+
+describe('4.2.8 Quasiquotation', () => {
+  test('simple', () => {
+    ew("`(list ,(+ 1 2) 4)").toBe("(list 3 4)");
+  })
+  test('binding', () => {
+    ew("(let ((name 'a)) `(list ,name ',name))").toBe("(list a (quote a))"); 
+  })
+  test('splicing', () => {
+    ew("`(a ,(+ 1 2) ,@(map abs '(4 -5 6)) b)").toBe("(a 3 4 5 6 b)");
+  })
+  test('improper list', () => {
+    ew("`(( foo ,(- 10 3)) ,@(cdr '(c)) . ,(car '(cons)))").toBe("((foo 7) . cons)");
+  })
+  test('nested', () => {
+    ew("`(a b `(c d))").toBe("(a b (quasiquote (c d)))");
+  })
+  test('nested + splicing', () => {
+    ew("(let1 ls '(4) `(1 `(2 ,(3 ,@ls))))")
+      .toBe("(1 (quasiquote (2 (unquote (3 4)))))");
+  })
+  test('vector quasiquotation', () => {
+    ew("`#(10 5 ,(sqrt 4) ,@(map sqrt '(16 9)) 8)").toBe("#(10 5 2 4 3 8)");
+  })
+  test('vector (nested)', () => {
+    ew("(let1 ls '(4) `#(1 `#(2 ,#(3 ,@ls))))")
+      .toBe("#(1 (quasiquote #(2 (unquote #(3 4)))))");
+  })
+  test('not a list', () => {
+    ew("`(,1 ,@2)").toBe("(1 . 2)");
+  })
+})
 
 describe('6.6 Characters', () => {
   test('char<?', function(){

--- a/test/r7rs/base.test.js
+++ b/test/r7rs/base.test.js
@@ -31,7 +31,12 @@ describe('4.2.8 Quasiquotation', () => {
     ew("`(,1 ,@2)").toBe("(1 . 2)");
   })
   test('bug #346', () => {
-    ew("(define l '(x y)) ``(,@,@l ,@,@l)").toBe("(quasiquote ((unquote-splicing x y) (unquote-splicing x y)))");
+    ew("(define l '(x y)) ``(,@,@l ,@,@l)").toBe(
+      "(quasiquote ((unquote-splicing x y) (unquote-splicing x y)))");
+    ew("(define x '(1 2)) \
+        (define y '(3 4)) \
+        (quasiquote ((unquote-splicing x y) (unquote-splicing x y)))")
+    .toBe("(1 2 3 4 1 2 3 4)");
   })
 })
 


### PR DESCRIPTION
This PR fixes `unquote`, `unquote-splicing` to accept multiple values.

fix #346 