### PR TITLE
Fix tuplespace chat server/client.  Set correct MIME type for javascript

### DIFF
--- a/tuplespace/chat.html
+++ b/tuplespace/chat.html
@@ -3,47 +3,19 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
   <title>BiwaScheme Chat</title>
+
+  <script src="../release/biwascheme-0.7.0.js"></script>
+  <script type="text/biwascheme">
+      (load "chat.scm")
+  </script>
 </head>
 <body>
+  chat
   <form>
     name:    <input id="name"><br>
     message: <input id="message"><input id="send" type="button" value="send">
   </form>
   <div id="bs-console"></div>
-
-  <script src="../lib/biwascheme.js">
-  (js-load "custom_biwa_lib.js" "BiwaScheme.CoreEnv['ts-init']")
-
-  (define *my-id* #f)
-  (define *msg-id* #f)
-
-  (add-handler! ($ "#send") "click"
-    (lambda ()
-      (let ((name (get-content ($ "#name")))
-            (msg  (get-content ($ "#message"))))
-        (ts-write (list 'message *my-id* name msg)))))
-
-  (define (receive-message)
-    (let ((v (ts-read `(message (? (lambda (x) (= (+ 1 ,*msg-id*) x))) _ _ _))))
-      (let ((new-msg-id (cadr v))
-            (sender-id  (caddr v))
-            (name       (cadddr v))
-            (message    (cadddr (cdr v))))
-        (set! *msg-id* new-msg-id)
-        (print "<" name ">" message)))
-    (receive-message))
-
-  (define (start-chat)
-    (ts-write '(connect))
-    (let ((state (ts-take '(connect _ _))))
-      (set! *my-id* (cadr state))
-      (set! *msg-id* (caddr state)))
-    (receive-message))
-
-  (ts-init)
-  (start-chat)
-  </script>
-
 </body>
 </html>
 <!-- vim:set ft=scheme: -->

--- a/tuplespace/chat.scm
+++ b/tuplespace/chat.scm
@@ -1,0 +1,31 @@
+(js-load "custom_biwa_lib.js" "BiwaScheme.CoreEnv['ts-init']")
+
+  (define *my-id* #f)
+  (define *msg-id* #f)
+
+  (add-handler! ($ "#send") "click"
+   (lambda ()
+      (console-log "sending " (get-content ($ "#message")))
+      (let ((name (get-content ($ "#name")))
+            (msg  (get-content ($ "#message"))))
+        (ts-write (list 'message *my-id* name msg)))))
+
+  (define (receive-message)
+    (let ((v (ts-read `(message (? (lambda (x) (= (+ 1 ,*msg-id*) x))) _ _ _))))
+      (let ((new-msg-id (cadr v))
+            (sender-id  (caddr v))
+            (name       (cadddr v))
+            (message    (cadddr (cdr v))))
+        (set! *msg-id* new-msg-id)
+        (print "<" name ">" message)))
+    (receive-message))
+
+  (define (start-chat)
+    (ts-write '(connect))
+    (let ((state (ts-take '(connect _ _))))
+      (set! *my-id* (cadr state))
+      (set! *msg-id* (caddr state)))
+    (receive-message))
+
+  (ts-init)
+  (start-chat)

--- a/tuplespace/inter_browser.scm
+++ b/tuplespace/inter_browser.scm
@@ -26,9 +26,10 @@
      (cons
        (file->string (build-path *httpd-document-root*
                               (string-drop (base-path-of req) 1)))
-       (if (rxmatch #/\.js/ (ref req 'path)) 
-           "text/javascript"
-           "text/html"))))
+       (cond ((rxmatch #/\.js/ (ref req 'path)) "text/javascript")
+             ((rxmatch #/\.css/ (ref req 'path)) "text/css")
+             ((rxmatch #/\.scm/ (ref req 'path)) "text/scheme")
+             (else "text/html")))))
 
 (sack-add-routing *sack*
   #/^\/reload$/

--- a/tuplespace/inter_browser.scm
+++ b/tuplespace/inter_browser.scm
@@ -23,8 +23,12 @@
 (sack-add-routing *sack*
   #/(\.html|\.js|\.css|\.scm)/
   (lambda (req)
-    (file->string (build-path *httpd-document-root*
-                              (string-drop (base-path-of req) 1)))))
+     (cons
+       (file->string (build-path *httpd-document-root*
+                              (string-drop (base-path-of req) 1)))
+       (if (rxmatch #/\.js/ (ref req 'path)) 
+           "text/javascript"
+           "text/html"))))
 
 (sack-add-routing *sack*
   #/^\/reload$/


### PR DESCRIPTION
The tuplespace example did not work out of the box as of July 2025.

Reason:
+ Tuplespace program relies on BiwaScheme.Class
+ Javascript was served with MIME type text/html

This pull req fixes these issues by

+ using older version of biwascheme (releases/biwascheme-0.7.0.js)
+ modify httpd-send-responce and related functions to set MIME type correctly for javascript

additionally biwa code in index.html is moved to its own file.

Ideally tuplespace/custom_biwa_lib.js should be rewritten so it's compatible with the newest version of biwascheme.